### PR TITLE
chore: add GitHub issue templates for batch work tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/batch-pr-cleanup.md
+++ b/.github/ISSUE_TEMPLATE/batch-pr-cleanup.md
@@ -1,0 +1,56 @@
+---
+name: Batch PR Cleanup
+about: Track cleanup of multiple related PRs
+title: '[Batch] '
+labels: ['batch-cleanup']
+assignees: ''
+
+---
+
+## PR Inventory
+
+| PR | Branch | Current State | Next Action |
+|----|--------|---------------|-------------|
+|  |  |  |  |
+
+## State Definitions
+
+```
+[needs-rebase] → [ready-for-review] → [needs-review] 
+                      ↑                    ↓
+               [implementing] ← [reviewed-needs-work]
+                      ↑                    ↓
+               [ready-for-review] → [ready-to-merge] → [MERGED]
+```
+
+- `status/needs-rebase` — Behind main or has conflicts
+- `status/ready-for-review` — Ready for human review pass
+- `status/needs-review` — Awaiting reviewer assignment
+- `status/reviewed-needs-work` — Reviewed, changes requested
+- `status/implementing` — Author addressing feedback
+- `status/ready-to-merge` — Green CI, approved, ready
+- `status/blocked-on-X` — Waiting for dependency
+- `status/abandoned` — Superseded, close me
+
+## Dependencies
+
+```
+PR #X → PR #Y → PR #Z
+```
+
+## Checklist
+
+- [ ] Full inventory: `gh pr list --state open`
+- [ ] Read each PR diff (not just files)
+- [ ] Apply status labels based on actual state
+- [ ] Identify review iteration cycles
+- [ ] Plan merge order
+- [ ] Spawn worktrees for mechanical rebases
+- [ ] Review before merge
+- [ ] Update golden files if needed
+- [ ] Verify alpha-check passes
+- [ ] Merge and delete branches
+- [ ] Update this issue as state changes
+
+## Notes
+

--- a/.github/ISSUE_TEMPLATE/research-and-planning.md
+++ b/.github/ISSUE_TEMPLATE/research-and-planning.md
@@ -1,0 +1,59 @@
+---
+name: Research and Planning
+about: Break down work into manageable chunks before implementation
+title: '[Plan] '
+labels: ['planning', 'research']
+assignees: ''
+
+---
+
+## Problem/Goal
+
+What are we trying to accomplish?
+
+## Research Questions
+
+- [ ] What do we need to learn?
+- [ ] What are the unknowns?
+- [ ] What could go wrong?
+
+## Decomposition
+
+Break into independent chunks:
+
+| Chunk | Estimate | Dependencies | Can Parallel? |
+|-------|----------|--------------|---------------|
+|  |  |  |  |
+
+## Spike Tasks
+
+- [ ] Research spike issue: #
+- [ ] Proof of concept:
+- [ ] ADR drafted:
+
+## Implementation Plan
+
+Order of operations:
+
+1. 
+2. 
+3. 
+
+## Spawn Strategy
+
+Which chunks spawn isolated sessions?
+
+| Chunk | Spawn? | Reason |
+|-------|--------|--------|
+|  |  |  |
+
+## Definition of Done
+
+- [ ] Research complete
+- [ ] Work decomposed into chunks < 2h each
+- [ ] Spawn strategy defined
+- [ ] Issues created for each chunk
+- [ ] PRs reference planning issue
+
+## Notes
+

--- a/.github/ISSUE_TEMPLATE/research-spike.md
+++ b/.github/ISSUE_TEMPLATE/research-spike.md
@@ -1,0 +1,28 @@
+---
+name: Research Spike
+about: Investigate a technical topic before implementation
+title: '[Research] '
+labels: ['research-spike']
+assignees: ''
+
+---
+
+## Topic
+
+## Questions to Answer
+
+- [ ] 
+- [ ] 
+
+## Deliverables
+
+- [ ] ADR created in `adr/` directory
+- [ ] Findings documented in `.mend/notes/`
+- [ ] Next steps identified
+
+## Timebox
+
+Hours: 
+
+## Notes
+

--- a/.github/ISSUE_TEMPLATE/scenario-activation.md
+++ b/.github/ISSUE_TEMPLATE/scenario-activation.md
@@ -1,0 +1,31 @@
+---
+name: Scenario Activation
+about: Activate a BDD scenario for alpha testing
+title: '[Activate] '
+labels: ['scenario-activation']
+assignees: ''
+
+---
+
+## Scenario
+
+- **ID:** 
+- **Feature:** 
+- **AC ID:** 
+
+## Pre-Activation Checklist
+
+- [ ] `@alpha-active` tag added to feature file
+- [ ] `ac_id` added to meta.yaml
+- [ ] `profile_pack` added to meta.yaml (if needed)
+- [ ] Step handlers implemented in `xbrlkit-bdd-steps`
+- [ ] AC assertion added to `scenario-runner`
+- [ ] AC added to `ACTIVE_ALPHA_ACS` in `xtask/src/alpha_check.rs`
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo xtask alpha-check` passes locally
+
+## Post-Merge
+
+- [ ] CI green on main
+- [ ] Update HEARTBEAT.md active scenario count
+


### PR DESCRIPTION
## Issue Templates

- **batch-pr-cleanup.md** — Track multiple PRs with review iteration states
- **research-and-planning.md** — Break work into chunks BEFORE implementation (REQUIRED)
- **scenario-activation.md** — Activate BDD scenarios
- **research-spike.md** — Technical investigations

## Status Labels (NEW)

### Review Iteration Cycle
```
[needs-rebase] → [ready-for-review] → [needs-review] 
                      ↑                    ↓
               [implementing] ← [reviewed-needs-work]
                      ↑                    ↓
               [ready-for-review] → [ready-to-merge] → [MERGED]
```

| Label | Color | Meaning |
|-------|-------|---------|
| `status/needs-rebase` | 🟡 Yellow | Behind main or conflicts |
| `status/ready-for-review` | 🟢 Light green | Ready for human review |
| `status/needs-review` | 🔴 Red | Awaiting reviewer |
| `status/reviewed-needs-work` | 🩷 Pink | Reviewed, changes needed |
| `status/implementing` | 🔵 Blue | Addressing feedback |
| `status/ready-to-merge` | 🟢 Green | Approved, green CI |
| `status/blocked-on-X` | 🟣 Purple | Dependency wait |
| `status/abandoned` | ⚪ Gray | Superseded |

## Workflow Change: Issue-First Planning (REQUIRED)

**NO implementation work without a planning issue.**

### Sequence
1. Create [Plan] issue from research-and-planning.md template
2. Research spike (if needed) → ADR
3. Decompose into chunks < 2 hours each
4. Define spawn strategy (what goes to isolated sessions)
5. THEN create implementation PRs
6. Reference planning issue in all PRs

### Why
- Forces decomposition before execution
- Prevents "just start coding" trap
- Makes parallel work explicit
- Audit trail of decisions

## Key Insight

Reviewed ≠ Ready. PRs can iterate through `reviewed-needs-work` → `implementing` → `ready-for-review` multiple times before reaching `ready-to-merge`.

Closes #18 (retro issue).