### PR TITLE
chore: add pre-push quality gate script

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Pre-push quality gate for xbrlkit
+# Usage: ./scripts/pre-push.sh
+
+set -e
+
+echo "🔍 Running pre-push checks..."
+
+echo "  → cargo fmt --all --check"
+cargo fmt --all --check
+
+echo "  → cargo clippy --workspace --all-targets -- -D warnings"
+cargo clippy --workspace --all-targets -- -D warnings
+
+echo "  → cargo test --workspace"
+cargo test --workspace
+
+echo "  → cargo xtask alpha-check"
+cargo xtask alpha-check
+
+echo "✅ All pre-push checks passed!"


### PR DESCRIPTION
Adds `scripts/pre-push.sh` to run all quality gates locally before push:

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo xtask alpha-check

This addresses friction encountered in PR #26 where multiple round trips were needed to catch clippy errors.