### PR TITLE
docs(queue): mark all scenarios complete

### DIFF
--- a/.mend/active.md
+++ b/.mend/active.md
@@ -6,30 +6,21 @@
 
 | Item | Value |
 |------|-------|
-| **Issue** | Feature grid (SCN-XK-WORKFLOW-001) |
-| **AC** | AC-XK-WORKFLOW-001 |
-| **Stream** | Workflow |
-| **Stage** | 🔍 Research |
-| **Started** | 2026-03-24 |
+| **Issue** | None |
+| **AC** | None |
+| **Stream** | - |
+| **Stage** | ✅ Idle |
+| **Started** | - |
 
 ## Scope
 
-Activate feature_grid.feature scenario:
-- SCN-XK-WORKFLOW-001: Generate a feature grid from active BDD feature files
+No active work in progress. Queue is empty.
 
-## Research Findings
+## Next Actions
 
-### Current State
-- Feature file: `specs/features/workflow/feature_grid.feature`
-- Grid generation likely exists (xtask feature-grid command)
-- No `@alpha-active` tag
-- Step handlers NOT implemented
-
-### Required Work
-1. Research feature grid structure and existing generation
-2. Add step handlers to xbrlkit-bdd-steps
-3. Implement grid validation logic
-4. Add @alpha-active tag
+- Monitor for new work items
+- Review friction scan findings
+- Continue CI health monitoring
 
 ---
 *This file is maintained by autonomous agents. Last updated: 2026-03-24*

--- a/.mend/pr-queue.md
+++ b/.mend/pr-queue.md
@@ -26,6 +26,7 @@
 
 | PR | Issue | Status | Commit | Notes |
 |----|-------|--------|--------|-------|
+| #46 | SCN-XK-WORKFLOW-001 | ✅ Complete | `0f3b522` | Feature grid scenario |
 | #44 | SCN-XK-MANIFEST-001 | ✅ Complete | `1cade92` | Filing manifest scenario |
 | #42 | SCN-XK-WORKFLOW-003 | ✅ Complete | `0ec270a` | Cockpit pack scenario |
 | #40 | SCN-XK-WORKFLOW-002/004 | ✅ Complete | `d966f3a` | Bundle scenarios activated |
@@ -40,7 +41,9 @@
 
 | # | Issue | Stream | Stage | Blocker |
 |---|-------|--------|-------|---------|
-| 1 | SCN-XK-WORKFLOW-001 | Workflow | 📋 Ready | None |
+| - | - | - | - | - |
+
+*Queue empty. All scenarios activated.*
 
 ## In Progress
 


### PR DESCRIPTION
Four scenarios activated today:

- #46: SCN-XK-WORKFLOW-001 (Feature grid)
- #44: SCN-XK-MANIFEST-001 (Filing manifest)
- #42: SCN-XK-WORKFLOW-003 (Cockpit pack)
- #40: SCN-XK-WORKFLOW-002/004 (Bundle)

19 @alpha-active scenarios passing. Queue now empty.