### PR TITLE
feat: Add repo-local maintainer wrappers for quick and full gates (Issue #4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,17 @@
 
 ## Commands
 
+### Maintainer Shortcuts
+
+For quick iteration, use the Makefile wrappers:
+
+```bash
+make quick    # Run quality gates (fmt, clippy, test) - fast feedback
+make full     # Run full alpha gate validation
+```
+
+### Direct Commands
+
 ```bash
 cargo xtask doctor
 cargo xtask feature-grid

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# xbrlkit Maintainer Wrappers
+# Issue #4: Quick gate and full gate shortcuts
+
+.PHONY: help quick full
+
+# Default target shows help
+help:
+	@echo "xbrlkit Maintainer Commands:"
+	@echo "  make quick    Run quality gates (fmt, clippy, test) - fast feedback"
+	@echo "  make full     Run full alpha gate validation"
+	@echo ""
+	@echo "For detailed commands, see CONTRIBUTING.md"
+
+# Quick gate: format, clippy, test (fast feedback)
+quick:
+	@echo "=== Running quick quality gates ==="
+	cargo fmt --check
+	cargo clippy --workspace -- -D warnings
+	cargo test --workspace
+	@echo "=== Quick gate passed ==="
+
+# Full gate: alpha-check (complete validation)
+full:
+	@echo "=== Running full alpha gate ==="
+	cargo xtask alpha-check
+	@echo "=== Full gate passed ==="


### PR DESCRIPTION
## Summary

This PR implements Issue #4 by adding a Makefile with convenient maintainer shortcuts.

## Changes

- **Makefile**: New file with two targets:
  - `make quick`: Runs fmt, clippy, and test for fast feedback
  - `make full`: Runs `cargo xtask alpha-check` for complete validation

- **CONTRIBUTING.md**: Updated to document the new make commands alongside existing cargo xtask commands

## Acceptance Criteria

- [x] `make quick` runs quality gates (fmt, clippy, test)
- [x] `make full` runs alpha-check
- [x] CONTRIBUTING.md documents the wrappers
- [x] All quality gates pass

## Testing

```bash
# Quick gate tested - all passed
make quick

# Full gate tested - all passed  
make full
```