### PR TITLE
feat(validation): Add typed value validation for dimensions (#57)

### DIFF
--- a/.mend/notes/typed-value-validation.md
+++ b/.mend/notes/typed-value-validation.md
@@ -1,0 +1,104 @@
+# Typed Value Validation Research
+
+## Overview
+Add validation for typed member values based on dimension's `value_type` from taxonomy.
+
+## Current State
+
+### taxonomy-dimensions Crate
+- `Dimension::Typed` variant contains `value_type: String` field
+- Example value types: `"xs:string"`, `"xs:date"`, `"xs:decimal"`, `"xs:boolean"`
+- `validate_member()` returns `Ok(())` for typed dimensions without value validation
+
+### dimensional-rules Crate  
+- `validate_dimension_member()` has TODO: "Add typed value validation based on dimension's value_type"
+- Currently returns `Ok(())` for typed dimensions without checking value format
+
+### xbrl-contexts Crate
+- `DimensionMember` stores:
+  - `is_typed: bool` - flag indicating typed dimension
+  - `typed_value: Option<String>` - the actual value
+  - `member: String` - duplicate of value for typed dimensions
+
+## XBRL Type System
+
+Common XBRL/XSD types to support:
+
+| Type | Pattern/Format | Example |
+|------|----------------|---------|
+| `xs:string` | Any string | "Hello" |
+| `xs:decimal` | Decimal number | "123.45", "-67" |
+| `xs:integer` | Whole number | "42", "-7" |
+| `xs:date` | ISO 8601 date | "2024-03-15" |
+| `xs:dateTime` | ISO 8601 datetime | "2024-03-15T10:30:00" |
+| `xs:boolean` | true/false/0/1 | "true", "1" |
+| `xs:anyURI` | Valid URI | "http://example.com" |
+
+## Validation Design
+
+### Approach
+1. Extract `value_type` from `Dimension::Typed`
+2. Parse and validate the typed value against the expected type
+3. Return specific validation error on type mismatch
+
+### Error Types
+- `XBRL.DIMENSION.INVALID_TYPED_VALUE` - value doesn't match expected type
+- `XBRL.DIMENSION.EMPTY_TYPED_VALUE` - typed value is empty/whitespace only
+
+### Implementation Location
+- Add `validate_typed_value()` function in `dimensional-rules`
+- Modify `validate_dimension_member()` to call it for typed dimensions
+
+### Type Validation Logic
+
+```rust
+fn validate_typed_value(value: &str, value_type: &str) -> Result<(), ValidationFinding> {
+    match value_type {
+        "xs:string" | "string" => Ok(()), // Any string is valid
+        "xs:decimal" | "decimal" => validate_decimal(value),
+        "xs:integer" | "integer" => validate_integer(value),
+        "xs:date" | "date" => validate_date(value),
+        "xs:dateTime" | "dateTime" => validate_datetime(value),
+        "xs:boolean" | "boolean" => validate_boolean(value),
+        "xs:anyURI" | "anyURI" => validate_uri(value),
+        _ => Ok(()), // Unknown types pass validation (extensibility)
+    }
+}
+```
+
+### Validation Patterns
+
+- **decimal**: Regex `^-?\d+(\.\d+)?$` or parse with `BigDecimal`
+- **integer**: Regex `^-?\d+$` or parse with `i64`
+- **date**: Try parse with `chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")`
+- **dateTime**: Try parse with `chrono::DateTime::parse_from_rfc3339`
+- **boolean**: Match against "true", "false", "1", "0" (case-insensitive)
+- **anyURI**: Use `url::Url::parse()` or basic URL validation
+
+## BDD Scenarios Needed
+
+New scenarios for `specs/features/taxonomy/dimensions.feature`:
+
+1. **Valid typed string value** - Any string passes
+2. **Valid typed decimal value** - "123.45" passes
+3. **Invalid typed decimal value** - "abc" fails
+4. **Valid typed date value** - "2024-03-15" passes  
+5. **Invalid typed date value** - "15-03-2024" fails
+6. **Valid typed boolean value** - "true" passes
+7. **Invalid typed boolean value** - "yes" fails
+8. **Empty typed value** - "" fails
+9. **Unknown type** - Custom type passes (extensibility)
+
+## Dependencies
+
+May need to add:
+- `chrono` for date/datetime parsing (likely already in workspace)
+- `regex` for pattern matching (optional, can use parse methods)
+
+## Acceptance Criteria
+
+- [x] Typed member values validated against dimension's `value_type`
+- [x] Support common XBRL types: string, decimal, date, boolean
+- [x] Validation errors for type mismatches
+- [x] BDD scenarios pass
+- [x] All quality gates pass

--- a/crates/dimensional-rules/src/lib.rs
+++ b/crates/dimensional-rules/src/lib.rs
@@ -159,10 +159,9 @@ fn validate_dimension_member(
     // Get the dimension definition
     let dimension = dim_taxonomy.dimensions.get(&dim_member.dimension).unwrap();
 
-    // If it's a typed dimension, the member is a value, not a QName
+    // If it's a typed dimension, validate the value against the expected type
     if dimension.is_typed() {
-        // TODO: Add typed value validation based on dimension's value_type
-        return Ok(());
+        return validate_typed_dimension_value(dim_member, dimension);
     }
 
     // For explicit dimensions, validate the member against the domain
@@ -191,6 +190,227 @@ fn validate_dimension_member(
         message: format!("Dimension {} has no domain defined", dim_member.dimension),
         member: Some(dim_member.dimension.clone()),
         subject: Some(dim_member.member.clone()),
+    })
+}
+
+/// Validate a typed dimension value against its declared `value_type`.
+fn validate_typed_dimension_value(
+    dim_member: &DimensionMember,
+    dimension: &taxonomy_dimensions::Dimension,
+) -> Result<(), ValidationFinding> {
+    let value = dim_member
+        .typed_value
+        .as_deref()
+        .unwrap_or(&dim_member.member);
+
+    // Get the value_type from the typed dimension
+    let value_type = match dimension {
+        taxonomy_dimensions::Dimension::Typed { value_type, .. } => value_type.as_str(),
+        taxonomy_dimensions::Dimension::Explicit { .. } => return Ok(()), // Should not happen since we checked is_typed()
+    };
+
+    // Check for empty value
+    if value.trim().is_empty() {
+        return Err(ValidationFinding {
+            rule_id: "XBRL.DIMENSION.EMPTY_TYPED_VALUE".to_string(),
+            severity: "error".to_string(),
+            message: format!("Typed dimension {} has empty value", dim_member.dimension),
+            member: Some(dim_member.dimension.clone()),
+            subject: Some(value.to_string()),
+        });
+    }
+
+    // Validate based on value_type
+    match value_type {
+        "xs:string" | "string" => Ok(()), // Any non-empty string is valid
+        "xs:decimal" | "decimal" => validate_decimal(value, dim_member),
+        "xs:integer" | "integer" => validate_integer(value, dim_member),
+        "xs:date" | "date" => validate_date(value, dim_member),
+        "xs:dateTime" | "dateTime" => validate_datetime(value, dim_member),
+        "xs:boolean" | "boolean" => validate_boolean(value, dim_member),
+        "xs:anyURI" | "anyURI" => validate_uri(value, dim_member),
+        _ => {
+            // Unknown types pass validation (extensibility)
+            Ok(())
+        }
+    }
+}
+
+/// Validate decimal format.
+fn validate_decimal(value: &str, dim_member: &DimensionMember) -> Result<(), ValidationFinding> {
+    // Check for valid decimal pattern: optional sign, digits, optional decimal point and digits
+    let trimmed = value.trim();
+    if trimmed
+        .chars()
+        .all(|c| c.is_ascii_digit() || c == '.' || c == '-' || c == '+')
+        && trimmed.chars().filter(|&c| c == '.').count() <= 1
+        && !trimmed.starts_with("..")
+        && !trimmed.ends_with('.')
+        && trimmed != "-"
+        && trimmed != "+"
+        && trimmed != "."
+        && trimmed != "-."
+        && trimmed != "+."
+    {
+        // Try to parse to ensure it's a valid number
+        if trimmed.parse::<f64>().is_ok() {
+            return Ok(());
+        }
+    }
+
+    Err(ValidationFinding {
+        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
+        severity: "error".to_string(),
+        message: format!(
+            "Value '{}' is not a valid decimal for dimension {}",
+            value, dim_member.dimension
+        ),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(value.to_string()),
+    })
+}
+
+/// Validate integer format.
+fn validate_integer(value: &str, dim_member: &DimensionMember) -> Result<(), ValidationFinding> {
+    let trimmed = value.trim();
+    if !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .skip_while(|&c| c == '-' || c == '+')
+            .all(|c| c.is_ascii_digit())
+        && trimmed != "-"
+        && trimmed != "+"
+        && trimmed.parse::<i64>().is_ok()
+    {
+        return Ok(());
+    }
+
+    Err(ValidationFinding {
+        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
+        severity: "error".to_string(),
+        message: format!(
+            "Value '{}' is not a valid integer for dimension {}",
+            value, dim_member.dimension
+        ),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(value.to_string()),
+    })
+}
+
+/// Validate date format (ISO 8601: YYYY-MM-DD).
+fn validate_date(value: &str, dim_member: &DimensionMember) -> Result<(), ValidationFinding> {
+    let trimmed = value.trim();
+
+    // Basic pattern check for YYYY-MM-DD
+    if trimmed.len() == 10 {
+        let parts: Vec<&str> = trimmed.split('-').collect();
+        if parts.len() == 3 {
+            // Validate year, month, day are numeric
+            if parts[0].len() == 4
+                && parts[0].chars().all(|c| c.is_ascii_digit())
+                && parts[1].len() == 2
+                && parts[1].chars().all(|c| c.is_ascii_digit())
+                && parts[2].len() == 2
+                && parts[2].chars().all(|c| c.is_ascii_digit())
+            {
+                // Additional validation for valid date ranges
+                if let (Ok(_year), Ok(month), Ok(day)) = (
+                    parts[0].parse::<u32>(),
+                    parts[1].parse::<u32>(),
+                    parts[2].parse::<u32>(),
+                ) {
+                    if (1..=12).contains(&month) && (1..=31).contains(&day) {
+                        // Basic check passed (full calendar validation optional)
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
+    Err(ValidationFinding {
+        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
+        severity: "error".to_string(),
+        message: format!(
+            "Value '{}' is not a valid date (expected YYYY-MM-DD) for dimension {}",
+            value, dim_member.dimension
+        ),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(value.to_string()),
+    })
+}
+
+/// Validate datetime format (ISO 8601).
+fn validate_datetime(value: &str, dim_member: &DimensionMember) -> Result<(), ValidationFinding> {
+    let trimmed = value.trim();
+
+    // Check for 'T' separator
+    if trimmed.contains('T') {
+        let parts: Vec<&str> = trimmed.split('T').collect();
+        if parts.len() == 2 {
+            // Validate date portion
+            if validate_date(parts[0], dim_member).is_ok() {
+                // Time portion: HH:MM:SS or HH:MM:SS.sss with optional timezone
+                let time_part = parts[1];
+                if !time_part.is_empty() {
+                    // Basic time validation - could be extended for full RFC 3339
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    Err(ValidationFinding {
+        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
+        severity: "error".to_string(),
+        message: format!(
+            "Value '{}' is not a valid dateTime for dimension {}",
+            value, dim_member.dimension
+        ),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(value.to_string()),
+    })
+}
+
+/// Validate boolean format.
+fn validate_boolean(value: &str, dim_member: &DimensionMember) -> Result<(), ValidationFinding> {
+    let trimmed = value.trim().to_lowercase();
+
+    if matches!(trimmed.as_str(), "true" | "false" | "1" | "0") {
+        return Ok(());
+    }
+
+    Err(ValidationFinding {
+        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
+        severity: "error".to_string(),
+        message: format!(
+            "Value '{}' is not a valid boolean (expected true/false/1/0) for dimension {}",
+            value, dim_member.dimension
+        ),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(value.to_string()),
+    })
+}
+
+/// Validate URI format.
+fn validate_uri(value: &str, dim_member: &DimensionMember) -> Result<(), ValidationFinding> {
+    // Basic URI validation: must have scheme:// or be an absolute/relative path
+    let trimmed = value.trim();
+
+    // Check for common URI patterns
+    if trimmed.contains("://") || trimmed.starts_with('/') || trimmed.starts_with("./") {
+        return Ok(());
+    }
+
+    Err(ValidationFinding {
+        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
+        severity: "error".to_string(),
+        message: format!(
+            "Value '{}' is not a valid URI for dimension {}",
+            value, dim_member.dimension
+        ),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(value.to_string()),
     })
 }
 
@@ -412,5 +632,239 @@ mod tests {
         assert_eq!(summary.contexts_with_missing_dims, 1);
         assert_eq!(summary.total_findings, 1);
         assert!(summary.unique_missing_dimensions.contains("dim1"));
+    }
+
+    fn create_test_typed_taxonomy(value_type: &str) -> DimensionTaxonomy {
+        let mut taxonomy = DimensionTaxonomy::new();
+
+        taxonomy.add_dimension(Dimension::Typed {
+            qname: "dim:TypedAxis".to_string(),
+            value_type: value_type.to_string(),
+            required: true,
+        });
+
+        taxonomy
+    }
+
+    fn create_test_context_with_typed_dim(id: &str, value: &str) -> Context {
+        Context {
+            id: id.to_string(),
+            entity: EntityIdentifier {
+                scheme: "http://www.sec.gov/CIK".to_string(),
+                value: "0000320193".to_string(),
+            },
+            entity_segment: None,
+            period: Period::Instant("2024-12-31".to_string()),
+            scenario: Some(DimensionalContainer {
+                dimensions: vec![DimensionMember {
+                    dimension: "dim:TypedAxis".to_string(),
+                    member: value.to_string(),
+                    is_typed: true,
+                    typed_value: Some(value.to_string()),
+                }],
+                raw_xml: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_validate_typed_string_value() {
+        let taxonomy = create_test_typed_taxonomy("xs:string");
+        let context = create_test_context_with_typed_dim("ctx-1", "Any string value");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            result.findings.is_empty(),
+            "Expected no findings for valid string value"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_decimal_value_valid() {
+        let taxonomy = create_test_typed_taxonomy("xs:decimal");
+        let context = create_test_context_with_typed_dim("ctx-1", "123.45");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            result.findings.is_empty(),
+            "Expected no findings for valid decimal value"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_decimal_value_invalid() {
+        let taxonomy = create_test_typed_taxonomy("xs:decimal");
+        let context = create_test_context_with_typed_dim("ctx-1", "not-a-number");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            !result.findings.is_empty(),
+            "Expected findings for invalid decimal value"
+        );
+        let has_invalid_value = result
+            .findings
+            .iter()
+            .any(|f| f.rule_id == "XBRL.DIMENSION.INVALID_TYPED_VALUE");
+        assert!(has_invalid_value, "Expected INVALID_TYPED_VALUE finding");
+    }
+
+    #[test]
+    fn test_validate_typed_integer_value_valid() {
+        let taxonomy = create_test_typed_taxonomy("xs:integer");
+        let context = create_test_context_with_typed_dim("ctx-1", "-42");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            result.findings.is_empty(),
+            "Expected no findings for valid integer value"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_integer_value_invalid() {
+        let taxonomy = create_test_typed_taxonomy("xs:integer");
+        let context = create_test_context_with_typed_dim("ctx-1", "3.14");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            !result.findings.is_empty(),
+            "Expected findings for invalid integer value"
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.rule_id == "XBRL.DIMENSION.INVALID_TYPED_VALUE")
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_date_value_valid() {
+        let taxonomy = create_test_typed_taxonomy("xs:date");
+        let context = create_test_context_with_typed_dim("ctx-1", "2024-03-15");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            result.findings.is_empty(),
+            "Expected no findings for valid date value"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_date_value_invalid() {
+        let taxonomy = create_test_typed_taxonomy("xs:date");
+        let context = create_test_context_with_typed_dim("ctx-1", "15-03-2024");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            !result.findings.is_empty(),
+            "Expected findings for invalid date value"
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.rule_id == "XBRL.DIMENSION.INVALID_TYPED_VALUE")
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_boolean_value_valid() {
+        let taxonomy = create_test_typed_taxonomy("xs:boolean");
+
+        for value in ["true", "false", "1", "0", "TRUE", "False"] {
+            let context = create_test_context_with_typed_dim("ctx-1", value);
+            let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+            assert!(
+                result.findings.is_empty(),
+                "Expected no findings for valid boolean value '{value}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_typed_boolean_value_invalid() {
+        let taxonomy = create_test_typed_taxonomy("xs:boolean");
+        let context = create_test_context_with_typed_dim("ctx-1", "yes");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            !result.findings.is_empty(),
+            "Expected findings for invalid boolean value"
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.rule_id == "XBRL.DIMENSION.INVALID_TYPED_VALUE")
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_empty_value() {
+        let taxonomy = create_test_typed_taxonomy("xs:string");
+        let context = create_test_context_with_typed_dim("ctx-1", "   ");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            !result.findings.is_empty(),
+            "Expected findings for empty typed value"
+        );
+        assert!(
+            result
+                .findings
+                .iter()
+                .any(|f| f.rule_id == "XBRL.DIMENSION.EMPTY_TYPED_VALUE")
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_unknown_type() {
+        // Unknown types should pass validation (extensibility)
+        let taxonomy = create_test_typed_taxonomy("custom:CustomType");
+        let context = create_test_context_with_typed_dim("ctx-1", "any value");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            result.findings.is_empty(),
+            "Expected no findings for unknown type (extensibility)"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_datetime_value_valid() {
+        let taxonomy = create_test_typed_taxonomy("xs:dateTime");
+        let context = create_test_context_with_typed_dim("ctx-1", "2024-03-15T10:30:00");
+
+        let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+
+        assert!(
+            result.findings.is_empty(),
+            "Expected no findings for valid datetime value"
+        );
+    }
+
+    #[test]
+    fn test_validate_typed_uri_value_valid() {
+        let taxonomy = create_test_typed_taxonomy("xs:anyURI");
+
+        for uri in ["http://example.com", "https://test.org/path", "/local/path"] {
+            let context = create_test_context_with_typed_dim("ctx-1", uri);
+            let result = validate_context_dimensions(&context, "us-gaap:Revenue", &taxonomy);
+            assert!(
+                result.findings.is_empty(),
+                "Expected no findings for valid URI '{uri}'"
+            );
+        }
     }
 }

--- a/crates/xbrlkit-bdd-steps/src/lib.rs
+++ b/crates/xbrlkit-bdd-steps/src/lib.rs
@@ -46,6 +46,7 @@ pub struct DimensionContext {
     pub concept: Option<String>,
     pub required_dimension: Option<String>,
     pub validation_findings: Vec<String>,
+    pub typed_value_type: Option<String>, // Added for typed value validation
 }
 
 impl World {
@@ -229,6 +230,24 @@ fn handle_given(world: &mut World, scenario: &ScenarioRecord, step: &Step) -> an
     if step.text == "a context without that dimension" {
         // Ensure dimension is not set (or clear it)
         world.dimension_context.dimension = None;
+        return Ok(true);
+    }
+
+    // Typed dimension Given steps
+    if let Some(dimension) = step.text.strip_prefix("a context with typed dimension \"") {
+        let rest = dimension.trim_end_matches('"');
+        // Handle "dim:Axis" of type "xs:type" format
+        if let Some((dim, type_part)) = rest.split_once("\" of type \"") {
+            world.dimension_context.dimension = Some(dim.to_string());
+            world.dimension_context.typed_value_type = Some(type_part.to_string());
+        } else {
+            world.dimension_context.dimension = Some(rest.to_string());
+        }
+        return Ok(true);
+    }
+
+    if let Some(value) = step.text.strip_prefix("the typed member value \"") {
+        world.dimension_context.member = Some(value.trim_end_matches('"').to_string());
         return Ok(true);
     }
 
@@ -433,6 +452,60 @@ fn handle_when(world: &mut World, scenario: &ScenarioRecord, step: &Step) -> any
                     .validation_findings
                     .push("XBRL.DIMENSION.MISSING_REQUIRED".to_string());
             }
+        }
+
+        return Ok(true);
+    }
+
+    if step.text == "I validate the typed dimension value" {
+        world.dimension_context.validation_findings.clear();
+
+        let dimension = world.dimension_context.dimension.as_deref().unwrap_or("");
+        let value = world.dimension_context.member.as_deref().unwrap_or("");
+        let value_type = world
+            .dimension_context
+            .typed_value_type
+            .as_deref()
+            .unwrap_or("xs:string");
+
+        // Build taxonomy with typed dimension
+        let mut taxonomy = DimensionTaxonomy::new();
+        taxonomy.add_dimension(Dimension::Typed {
+            qname: dimension.to_string(),
+            value_type: value_type.to_string(),
+            required: false,
+        });
+
+        // Build context with typed dimension
+        let context = xbrl_contexts::Context {
+            id: "test-context".to_string(),
+            entity: EntityIdentifier {
+                scheme: "http://www.sec.gov/CIK".to_string(),
+                value: "0001234567".to_string(),
+            },
+            period: Period::Duration {
+                start: "2024-01-01".to_string(),
+                end: "2024-12-31".to_string(),
+            },
+            entity_segment: None,
+            scenario: Some(DimensionalContainer {
+                dimensions: vec![DimensionMember {
+                    dimension: dimension.to_string(),
+                    member: value.to_string(),
+                    is_typed: true,
+                    typed_value: Some(value.to_string()),
+                }],
+                raw_xml: None,
+            }),
+        };
+
+        // Validate
+        let result = validate_context_dimensions(&context, "", &taxonomy);
+        for finding in result.findings {
+            world
+                .dimension_context
+                .validation_findings
+                .push(finding.rule_id.clone());
         }
 
         return Ok(true);

--- a/specs/features/taxonomy/dimensions.feature
+++ b/specs/features/taxonomy/dimensions.feature
@@ -75,3 +75,75 @@ Feature: XBRL Dimensional Validation
     When I parse the context dimensions
     Then the dimension should be marked as typed
     And the typed value should be empty
+
+  @alpha-active @SCN-XK-DIM-009 @AC-XK-DIM-009
+  Scenario: Valid typed decimal value passes validation
+    Given a context with typed dimension "dim:AmountAxis" of type "xs:decimal"
+    And the typed member value "123.45"
+    When I validate the typed dimension value
+    Then the validation should pass
+    And no findings should be reported
+
+  @alpha-active @SCN-XK-DIM-010 @AC-XK-DIM-010
+  Scenario: Invalid typed decimal value fails validation
+    Given a context with typed dimension "dim:AmountAxis" of type "xs:decimal"
+    And the typed member value "not-a-number"
+    When I validate the typed dimension value
+    Then the validation should fail
+    And an "XBRL.DIMENSION.INVALID_TYPED_VALUE" finding should be reported
+
+  @alpha-active @SCN-XK-DIM-011 @AC-XK-DIM-011
+  Scenario: Valid typed date value passes validation
+    Given a context with typed dimension "dim:ReportDateAxis" of type "xs:date"
+    And the typed member value "2024-03-15"
+    When I validate the typed dimension value
+    Then the validation should pass
+    And no findings should be reported
+
+  @alpha-active @SCN-XK-DIM-012 @AC-XK-DIM-012
+  Scenario: Invalid typed date value fails validation
+    Given a context with typed dimension "dim:ReportDateAxis" of type "xs:date"
+    And the typed member value "15-03-2024"
+    When I validate the typed dimension value
+    Then the validation should fail
+    And an "XBRL.DIMENSION.INVALID_TYPED_VALUE" finding should be reported
+
+  @alpha-active @SCN-XK-DIM-013 @AC-XK-DIM-013
+  Scenario: Valid typed boolean value passes validation
+    Given a context with typed dimension "dim:IsActiveAxis" of type "xs:boolean"
+    And the typed member value "true"
+    When I validate the typed dimension value
+    Then the validation should pass
+    And no findings should be reported
+
+  @alpha-active @SCN-XK-DIM-014 @AC-XK-DIM-014
+  Scenario: Invalid typed boolean value fails validation
+    Given a context with typed dimension "dim:IsActiveAxis" of type "xs:boolean"
+    And the typed member value "yes"
+    When I validate the typed dimension value
+    Then the validation should fail
+    And an "XBRL.DIMENSION.INVALID_TYPED_VALUE" finding should be reported
+
+  @alpha-active @SCN-XK-DIM-015 @AC-XK-DIM-015
+  Scenario: Empty typed value fails validation
+    Given a context with typed dimension "dim:RequiredAxis" of type "xs:string"
+    And the typed member value ""
+    When I validate the typed dimension value
+    Then the validation should fail
+    And an "XBRL.DIMENSION.EMPTY_TYPED_VALUE" finding should be reported
+
+  @alpha-active @SCN-XK-DIM-016 @AC-XK-DIM-016
+  Scenario: Valid typed integer value passes validation
+    Given a context with typed dimension "dim:CountAxis" of type "xs:integer"
+    And the typed member value "-42"
+    When I validate the typed dimension value
+    Then the validation should pass
+    And no findings should be reported
+
+  @alpha-active @SCN-XK-DIM-017 @AC-XK-DIM-017
+  Scenario: Invalid typed integer value fails validation
+    Given a context with typed dimension "dim:CountAxis" of type "xs:integer"
+    And the typed member value "3.14"
+    When I validate the typed dimension value
+    Then the validation should fail
+    And an "XBRL.DIMENSION.INVALID_TYPED_VALUE" finding should be reported


### PR DESCRIPTION
Implements Issue #57: Typed value validation for dimensions.

## Changes
- Add validation for typed member values against dimension value_type
- Support common XBRL types: string, decimal, integer, boolean, date, dateTime
- Add validation rules for type mismatches
- Add BDD scenarios for typed value validation
- All quality gates pass

Closes #57