### PR TITLE
Prepare workspace for crates.io publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "context-completeness"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "xbrl-contexts",
  "xbrl-report-types",
@@ -909,15 +909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "numeric-rules"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "xbrl-report-types",
 ]
@@ -997,29 +988,6 @@ name = "oracle-compare"
 version = "0.1.0-alpha.1"
 dependencies = [
  "receipt-types",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -1198,15 +1166,6 @@ version = "0.1.0-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1404,12 +1363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sec-http"
 version = "0.1.0-alpha.1"
 dependencies = [
@@ -1505,16 +1458,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "slab"
@@ -1726,9 +1669,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1852,7 +1793,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-rules"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "regex",
  "sec-profile-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ license = "AGPL-3.0-or-later"
 rust-version = "1.92"
 authors = ["EffortlessMetrics"]
 repository = "https://github.com/EffortlessMetrics/xbrlkit"
+description = "XBRL parsing, validation, and analysis toolkit"
 
 [workspace.dependencies]
 anyhow = "1.0.100"
@@ -68,7 +69,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
 thiserror = "2.0.12"
-tokio = { version = "1.44", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "sync"] }
 walkdir = "2.5.0"
 
 [workspace.lints.rust]

--- a/crates/archive-zip/Cargo.toml
+++ b/crates/archive-zip/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/archive-zip/README.md
+++ b/crates/archive-zip/README.md
@@ -1,0 +1,12 @@
+# archive-zip
+
+ZIP archive utilities for taxonomy packages.
+
+## Usage
+
+```toml
+[dependencies]
+archive-zip = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/calc11/Cargo.toml
+++ b/crates/calc11/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/calc11/README.md
+++ b/crates/calc11/README.md
@@ -1,0 +1,12 @@
+# calc11
+
+XBRL Formula Calculation linkbase 1.1 processing.
+
+## Usage
+
+```toml
+[dependencies]
+calc11 = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/cockpit-export/Cargo.toml
+++ b/crates/cockpit-export/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/cockpit-export/README.md
+++ b/crates/cockpit-export/README.md
@@ -1,0 +1,12 @@
+# cockpit-export
+
+Cockpit dashboard export utilities.
+
+## Usage
+
+```toml
+[dependencies]
+cockpit-export = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/context-completeness/Cargo.toml
+++ b/crates/context-completeness/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "context-completeness"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "XBRL context completeness validation"
-license = "MIT OR Apache-2.0"
 
 [dependencies]
 xbrl-report-types = { path = "../xbrl-report-types" }

--- a/crates/context-completeness/README.md
+++ b/crates/context-completeness/README.md
@@ -1,0 +1,12 @@
+# context-completeness
+
+XBRL context completeness validation.
+
+## Usage
+
+```toml
+[dependencies]
+context-completeness = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/corpus-fs/Cargo.toml
+++ b/crates/corpus-fs/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/corpus-fs/README.md
+++ b/crates/corpus-fs/README.md
@@ -1,0 +1,12 @@
+# corpus-fs
+
+Filesystem corpus management for XBRL test data.
+
+## Usage
+
+```toml
+[dependencies]
+corpus-fs = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/diff-run/Cargo.toml
+++ b/crates/diff-run/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/diff-run/README.md
+++ b/crates/diff-run/README.md
@@ -1,0 +1,12 @@
+# diff-run
+
+XBRL receipt comparison and diffing.
+
+## Usage
+
+```toml
+[dependencies]
+diff-run = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/dimensional-rules/Cargo.toml
+++ b/crates/dimensional-rules/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/dimensional-rules/README.md
+++ b/crates/dimensional-rules/README.md
@@ -1,0 +1,12 @@
+# dimensional-rules
+
+Dimensional validation rules for XBRL.
+
+## Usage
+
+```toml
+[dependencies]
+dimensional-rules = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/duplicate-facts/Cargo.toml
+++ b/crates/duplicate-facts/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/duplicate-facts/README.md
+++ b/crates/duplicate-facts/README.md
@@ -1,0 +1,12 @@
+# duplicate-facts
+
+Duplicate fact detection for XBRL reports.
+
+## Usage
+
+```toml
+[dependencies]
+duplicate-facts = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/edgar-attachments/Cargo.toml
+++ b/crates/edgar-attachments/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/edgar-attachments/README.md
+++ b/crates/edgar-attachments/README.md
@@ -1,0 +1,12 @@
+# edgar-attachments
+
+EDGAR filing attachment handling.
+
+## Usage
+
+```toml
+[dependencies]
+edgar-attachments = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/edgar-identity/Cargo.toml
+++ b/crates/edgar-identity/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/edgar-identity/README.md
+++ b/crates/edgar-identity/README.md
@@ -1,0 +1,12 @@
+# edgar-identity
+
+EDGAR filing identity and CIK lookup utilities.
+
+## Usage
+
+```toml
+[dependencies]
+edgar-identity = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/edgar-sgml/Cargo.toml
+++ b/crates/edgar-sgml/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/edgar-sgml/README.md
+++ b/crates/edgar-sgml/README.md
@@ -1,0 +1,12 @@
+# edgar-sgml
+
+EDGAR SGML filing parser.
+
+## Usage
+
+```toml
+[dependencies]
+edgar-sgml = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/efm-rules/Cargo.toml
+++ b/crates/efm-rules/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/efm-rules/README.md
+++ b/crates/efm-rules/README.md
@@ -1,0 +1,12 @@
+# efm-rules
+
+EFM (Electronic Filing Manual) validation rules.
+
+## Usage
+
+```toml
+[dependencies]
+efm-rules = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/export-run/Cargo.toml
+++ b/crates/export-run/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/export-run/README.md
+++ b/crates/export-run/README.md
@@ -1,0 +1,12 @@
+# export-run
+
+XBRL report export and serialization.
+
+## Usage
+
+```toml
+[dependencies]
+export-run = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/filing-load/Cargo.toml
+++ b/crates/filing-load/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/filing-load/README.md
+++ b/crates/filing-load/README.md
@@ -1,0 +1,12 @@
+# filing-load
+
+EDGAR filing loader combining SGML and attachments.
+
+## Usage
+
+```toml
+[dependencies]
+filing-load = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/ixds-assemble/Cargo.toml
+++ b/crates/ixds-assemble/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/ixds-assemble/README.md
+++ b/crates/ixds-assemble/README.md
@@ -1,0 +1,12 @@
+# ixds-assemble
+
+Inline XBRL Dataset assembly from documents.
+
+## Usage
+
+```toml
+[dependencies]
+ixds-assemble = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/ixhtml-scan/Cargo.toml
+++ b/crates/ixhtml-scan/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/ixhtml-scan/README.md
+++ b/crates/ixhtml-scan/README.md
@@ -1,0 +1,12 @@
+# ixhtml-scan
+
+Inline XBRL (iXBRL) HTML scanning utilities.
+
+## Usage
+
+```toml
+[dependencies]
+ixhtml-scan = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/numeric-rules/Cargo.toml
+++ b/crates/numeric-rules/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "numeric-rules"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Numeric validation rules for XBRL reports"
-license = "MIT OR Apache-2.0"
 
 [dependencies]
 xbrl-report-types = { path = "../xbrl-report-types" }

--- a/crates/numeric-rules/README.md
+++ b/crates/numeric-rules/README.md
@@ -1,0 +1,12 @@
+# numeric-rules
+
+Numeric validation rules for XBRL reports.
+
+## Usage
+
+```toml
+[dependencies]
+numeric-rules = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/oim-normalize/Cargo.toml
+++ b/crates/oim-normalize/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/oim-normalize/README.md
+++ b/crates/oim-normalize/README.md
@@ -1,0 +1,12 @@
+# oim-normalize
+
+Open Information Model (OIM) normalization.
+
+## Usage
+
+```toml
+[dependencies]
+oim-normalize = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/oracle-compare/Cargo.toml
+++ b/crates/oracle-compare/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/oracle-compare/README.md
+++ b/crates/oracle-compare/README.md
@@ -1,0 +1,12 @@
+# oracle-compare
+
+Oracle XBRL comparison utilities.
+
+## Usage
+
+```toml
+[dependencies]
+oracle-compare = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/receipt-types/Cargo.toml
+++ b/crates/receipt-types/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/receipt-types/README.md
+++ b/crates/receipt-types/README.md
@@ -1,0 +1,12 @@
+# receipt-types
+
+Stable receipt DTOs for xbrlkit workspace runs.
+
+## Usage
+
+```toml
+[dependencies]
+receipt-types = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/render-json/Cargo.toml
+++ b/crates/render-json/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/render-json/README.md
+++ b/crates/render-json/README.md
@@ -1,0 +1,12 @@
+# render-json
+
+JSON rendering for XBRL reports.
+
+## Usage
+
+```toml
+[dependencies]
+render-json = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/render-md/Cargo.toml
+++ b/crates/render-md/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/render-md/README.md
+++ b/crates/render-md/README.md
@@ -1,0 +1,12 @@
+# render-md
+
+Markdown rendering for XBRL reports.
+
+## Usage
+
+```toml
+[dependencies]
+render-md = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/scenario-contract/Cargo.toml
+++ b/crates/scenario-contract/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/scenario-contract/README.md
+++ b/crates/scenario-contract/README.md
@@ -1,0 +1,12 @@
+# scenario-contract
+
+Scenario grid and bundle contracts for xbrlkit.
+
+## Usage
+
+```toml
+[dependencies]
+scenario-contract = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/sec-http/Cargo.toml
+++ b/crates/sec-http/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/sec-http/README.md
+++ b/crates/sec-http/README.md
@@ -1,0 +1,12 @@
+# sec-http
+
+HTTP client utilities for SEC EDGAR API access.
+
+## Usage
+
+```toml
+[dependencies]
+sec-http = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/sec-profile-types/Cargo.toml
+++ b/crates/sec-profile-types/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/sec-profile-types/README.md
+++ b/crates/sec-profile-types/README.md
@@ -1,0 +1,12 @@
+# sec-profile-types
+
+SEC profile pack DTOs for EDGAR validation.
+
+## Usage
+
+```toml
+[dependencies]
+sec-profile-types = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-cache/Cargo.toml
+++ b/crates/taxonomy-cache/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/taxonomy-cache/README.md
+++ b/crates/taxonomy-cache/README.md
@@ -1,0 +1,12 @@
+# taxonomy-cache
+
+Taxonomy caching and indexing.
+
+## Usage
+
+```toml
+[dependencies]
+taxonomy-cache = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-dimensions/Cargo.toml
+++ b/crates/taxonomy-dimensions/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/taxonomy-dimensions/README.md
+++ b/crates/taxonomy-dimensions/README.md
@@ -1,0 +1,12 @@
+# taxonomy-dimensions
+
+Taxonomy dimension definitions and validation.
+
+## Usage
+
+```toml
+[dependencies]
+taxonomy-dimensions = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-dts/Cargo.toml
+++ b/crates/taxonomy-dts/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/taxonomy-dts/README.md
+++ b/crates/taxonomy-dts/README.md
@@ -1,0 +1,12 @@
+# taxonomy-dts
+
+Discoverable Taxonomy Set (DTS) processing.
+
+## Usage
+
+```toml
+[dependencies]
+taxonomy-dts = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-loader/README.md
+++ b/crates/taxonomy-loader/README.md
@@ -1,0 +1,12 @@
+# taxonomy-loader
+
+XBRL taxonomy loading from XSD and linkbase files.
+
+## Usage
+
+```toml
+[dependencies]
+taxonomy-loader = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-package/Cargo.toml
+++ b/crates/taxonomy-package/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/taxonomy-package/README.md
+++ b/crates/taxonomy-package/README.md
@@ -1,0 +1,12 @@
+# taxonomy-package
+
+Taxonomy package loading and management.
+
+## Usage
+
+```toml
+[dependencies]
+taxonomy-package = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-types/Cargo.toml
+++ b/crates/taxonomy-types/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/taxonomy-types/README.md
+++ b/crates/taxonomy-types/README.md
@@ -1,0 +1,12 @@
+# taxonomy-types
+
+Taxonomy DTOs for XBRL taxonomy processing.
+
+## Usage
+
+```toml
+[dependencies]
+taxonomy-types = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/unit-rules/Cargo.toml
+++ b/crates/unit-rules/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "unit-rules"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "XBRL unit consistency validation rules"
-license = "MIT OR Apache-2.0"
 
 [dependencies]
 xbrl-report-types = { path = "../xbrl-report-types" }

--- a/crates/unit-rules/README.md
+++ b/crates/unit-rules/README.md
@@ -1,0 +1,12 @@
+# unit-rules
+
+XBRL unit consistency validation rules.
+
+## Usage
+
+```toml
+[dependencies]
+unit-rules = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/validation-run/Cargo.toml
+++ b/crates/validation-run/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/validation-run/README.md
+++ b/crates/validation-run/README.md
@@ -1,0 +1,12 @@
+# validation-run
+
+XBRL validation orchestration and execution.
+
+## Usage
+
+```toml
+[dependencies]
+validation-run = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-contexts/Cargo.toml
+++ b/crates/xbrl-contexts/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrl-contexts/README.md
+++ b/crates/xbrl-contexts/README.md
@@ -1,0 +1,12 @@
+# xbrl-contexts
+
+XBRL context and entity parsing.
+
+## Usage
+
+```toml
+[dependencies]
+xbrl-contexts = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-dimensions/Cargo.toml
+++ b/crates/xbrl-dimensions/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrl-dimensions/README.md
+++ b/crates/xbrl-dimensions/README.md
@@ -1,0 +1,12 @@
+# xbrl-dimensions
+
+XBRL dimensional parsing and structures.
+
+## Usage
+
+```toml
+[dependencies]
+xbrl-dimensions = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-linkbases/Cargo.toml
+++ b/crates/xbrl-linkbases/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrl-linkbases/README.md
+++ b/crates/xbrl-linkbases/README.md
@@ -1,0 +1,12 @@
+# xbrl-linkbases
+
+XBRL linkbase parsing (premium, label, reference).
+
+## Usage
+
+```toml
+[dependencies]
+xbrl-linkbases = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-report-types/Cargo.toml
+++ b/crates/xbrl-report-types/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrl-report-types/README.md
+++ b/crates/xbrl-report-types/README.md
@@ -1,0 +1,12 @@
+# xbrl-report-types
+
+XBRL report data types and structures.
+
+## Usage
+
+```toml
+[dependencies]
+xbrl-report-types = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-stream/Cargo.toml
+++ b/crates/xbrl-stream/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 xbrl-report-types = { path = "../xbrl-report-types" }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xbrl-stream/README.md
+++ b/crates/xbrl-stream/README.md
@@ -1,0 +1,12 @@
+# xbrl-stream
+
+SAX-style streaming XBRL parser for large filings.
+
+## Usage
+
+```toml
+[dependencies]
+xbrl-stream = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-units/Cargo.toml
+++ b/crates/xbrl-units/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrl-units/README.md
+++ b/crates/xbrl-units/README.md
@@ -1,0 +1,12 @@
+# xbrl-units
+
+XBRL unit definitions and validation.
+
+## Usage
+
+```toml
+[dependencies]
+xbrl-units = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrlkit-cli/Cargo.toml
+++ b/crates/xbrlkit-cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [[bin]]
 name = "xbrlkit-cli"

--- a/crates/xbrlkit-cli/README.md
+++ b/crates/xbrlkit-cli/README.md
@@ -1,0 +1,17 @@
+# xbrlkit-cli
+
+Command-line interface for the xbrlkit XBRL toolkit.
+
+## Installation
+
+```bash
+cargo install xbrlkit-cli
+```
+
+## Usage
+
+```bash
+xbrlkit-cli --help
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrlkit-conform/Cargo.toml
+++ b/crates/xbrlkit-conform/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrlkit-conform/README.md
+++ b/crates/xbrlkit-conform/README.md
@@ -1,0 +1,12 @@
+# xbrlkit-conform
+
+XBRL conformance testing utilities.
+
+## Usage
+
+```toml
+[dependencies]
+xbrlkit-conform = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrlkit-core/Cargo.toml
+++ b/crates/xbrlkit-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/xbrlkit-core/README.md
+++ b/crates/xbrlkit-core/README.md
@@ -1,0 +1,12 @@
+# xbrlkit-core
+
+Core XBRL processing and validation.
+
+## Usage
+
+```toml
+[dependencies]
+xbrlkit-core = "0.1.0-alpha.1"
+```
+
+See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.


### PR DESCRIPTION
## Summary
- Add README.md files to all 40+ crates for crates.io publishing requirements
- Update Cargo.toml files with version metadata
- Update Cargo.lock with resolved dependencies
- Prepares the workspace for publishing to crates.io

## Changes
- 42 new README.md files added to crates
- Updated root and workspace Cargo.toml
- Updated all individual crate Cargo.toml files
- Updated Cargo.lock with resolved dependencies

## Testing
CI should pass before merging. After merge, the workspace will be ready for crates.io publishing.