### PR TITLE
chore: prefix unpublished crate package names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,26 +200,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cockpit-export"
-version = "0.1.0-alpha.1"
-dependencies = [
- "receipt-types",
- "serde_json",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "context-completeness"
-version = "0.1.0-alpha.1"
-dependencies = [
- "xbrl-contexts",
- "xbrl-report-types",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -235,25 +219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff-run"
-version = "0.1.0-alpha.1"
-dependencies = [
- "receipt-types",
- "xbrl-report-types",
-]
-
-[[package]]
-name = "dimensional-rules"
-version = "0.1.0-alpha.1"
-dependencies = [
- "serde",
- "taxonomy-dimensions",
- "thiserror 2.0.18",
- "xbrl-contexts",
- "xbrl-report-types",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,42 +230,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "duplicate-facts"
-version = "0.1.0-alpha.1"
-dependencies = [
- "xbrl-report-types",
-]
-
-[[package]]
-name = "edgar-attachments"
-version = "0.1.0-alpha.1"
-dependencies = [
- "edgar-identity",
- "serde",
-]
-
-[[package]]
 name = "edgar-identity"
 version = "0.1.0-alpha.1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "edgar-sgml"
-version = "0.1.0-alpha.1"
-dependencies = [
- "edgar-identity",
-]
-
-[[package]]
-name = "efm-rules"
-version = "0.1.0-alpha.1"
-dependencies = [
- "ixhtml-scan",
- "sec-profile-types",
- "taxonomy-dts",
- "xbrl-report-types",
 ]
 
 [[package]]
@@ -320,29 +253,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "export-run"
-version = "0.1.0-alpha.1"
-dependencies = [
- "oim-normalize",
- "receipt-types",
- "serde_json",
- "xbrl-report-types",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "filing-load"
-version = "0.1.0-alpha.1"
-dependencies = [
- "edgar-attachments",
- "edgar-sgml",
- "receipt-types",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -748,14 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "ixds-assemble"
-version = "0.1.0-alpha.1"
-dependencies = [
- "ixhtml-scan",
- "xbrl-report-types",
-]
-
-[[package]]
 name = "ixhtml-scan"
 version = "0.1.0-alpha.1"
 dependencies = [
@@ -835,21 +741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numeric-rules"
-version = "0.1.0-alpha.1"
-dependencies = [
- "xbrl-report-types",
-]
-
-[[package]]
-name = "oim-normalize"
-version = "0.1.0-alpha.1"
-dependencies = [
- "serde_json",
- "xbrl-report-types",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,13 +751,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "oracle-compare"
-version = "0.1.0-alpha.1"
-dependencies = [
- "receipt-types",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1076,14 +960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "render-json"
-version = "0.1.0-alpha.1"
-
-[[package]]
-name = "render-md"
-version = "0.1.0-alpha.1"
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,47 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scenario-contract"
-version = "0.1.0-alpha.1"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "scenario-runner"
-version = "0.1.0-alpha.1"
-dependencies = [
- "anyhow",
- "export-run",
- "receipt-types",
- "scenario-contract",
- "sec-profile-types",
- "serde",
- "serde_json",
- "serde_yaml",
- "validation-run",
- "xbrl-report-types",
-]
-
-[[package]]
-name = "sec-http"
-version = "0.1.0-alpha.1"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
-name = "sec-profile-types"
-version = "0.1.0-alpha.1"
-dependencies = [
- "anyhow",
- "serde",
- "serde_yaml",
- "taxonomy-types",
 ]
 
 [[package]]
@@ -1408,57 +1243,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "taxonomy-cache"
-version = "0.1.0-alpha.1"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
-name = "taxonomy-dimensions"
-version = "0.1.0-alpha.1"
-dependencies = [
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "taxonomy-dts"
-version = "0.1.0-alpha.1"
-dependencies = [
- "sec-profile-types",
- "taxonomy-types",
-]
-
-[[package]]
-name = "taxonomy-loader"
-version = "0.1.0-alpha.1"
-dependencies = [
- "reqwest",
- "roxmltree",
- "serde_json",
- "taxonomy-dimensions",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "taxonomy-package"
-version = "0.1.0-alpha.1"
-dependencies = [
- "taxonomy-types",
-]
-
-[[package]]
-name = "taxonomy-types"
-version = "0.1.0-alpha.1"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1658,16 +1442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unit-rules"
-version = "0.1.0-alpha.1"
-dependencies = [
- "regex",
- "sec-profile-types",
- "serde",
- "xbrl-report-types",
-]
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,27 +1476,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "validation-run"
-version = "0.1.0-alpha.1"
-dependencies = [
- "anyhow",
- "context-completeness",
- "dimensional-rules",
- "duplicate-facts",
- "efm-rules",
- "ixds-assemble",
- "numeric-rules",
- "receipt-types",
- "sec-profile-types",
- "taxonomy-dimensions",
- "taxonomy-dts",
- "taxonomy-types",
- "xbrl-contexts",
- "xbrl-report-types",
- "xbrl-stream",
-]
 
 [[package]]
 name = "walkdir"
@@ -2208,53 +1961,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "xbrl-contexts"
-version = "0.1.0-alpha.1"
-dependencies = [
- "roxmltree",
- "serde",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "xbrl-dimensions"
-version = "0.1.0-alpha.1"
-
-[[package]]
-name = "xbrl-linkbases"
-version = "0.1.0-alpha.1"
-
-[[package]]
-name = "xbrl-report-types"
-version = "0.1.0-alpha.1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "xbrl-stream"
-version = "0.1.0-alpha.1"
-dependencies = [
- "anyhow",
- "quick-xml",
- "thiserror 1.0.69",
- "tokio",
- "xbrl-report-types",
-]
-
-[[package]]
-name = "xbrl-units"
-version = "0.1.0-alpha.1"
-
-[[package]]
 name = "xbrlkit-bdd"
 version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "receipt-types",
- "scenario-contract",
  "walkdir",
  "xbrlkit-bdd-steps",
+ "xbrlkit-scenario-contract",
 ]
 
 [[package]]
@@ -2262,24 +1976,24 @@ name = "xbrlkit-bdd-steps"
 version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
- "cockpit-export",
- "context-completeness",
- "dimensional-rules",
- "edgar-attachments",
- "filing-load",
- "numeric-rules",
  "receipt-types",
- "scenario-contract",
- "scenario-runner",
- "sec-profile-types",
  "serde_json",
- "taxonomy-dimensions",
- "taxonomy-loader",
  "walkdir",
- "xbrl-contexts",
- "xbrl-report-types",
- "xbrl-stream",
+ "xbrlkit-cockpit-export",
+ "xbrlkit-context-completeness",
+ "xbrlkit-dimensional-rules",
+ "xbrlkit-edgar-attachments",
  "xbrlkit-feature-grid",
+ "xbrlkit-filing-load",
+ "xbrlkit-numeric-rules",
+ "xbrlkit-scenario-contract",
+ "xbrlkit-scenario-runner",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-taxonomy-dimensions",
+ "xbrlkit-taxonomy-loader",
+ "xbrlkit-xbrl-contexts",
+ "xbrlkit-xbrl-report-types",
+ "xbrlkit-xbrl-stream",
 ]
 
 [[package]]
@@ -2289,17 +2003,25 @@ dependencies = [
  "anyhow",
  "clap",
  "corpus-fs",
- "export-run",
- "render-json",
- "render-md",
- "sec-profile-types",
  "serde_json",
  "serde_yaml",
- "taxonomy-dimensions",
- "taxonomy-loader",
- "validation-run",
- "xbrl-contexts",
- "xbrl-report-types",
+ "xbrlkit-export-run",
+ "xbrlkit-render-json",
+ "xbrlkit-render-md",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-taxonomy-dimensions",
+ "xbrlkit-taxonomy-loader",
+ "xbrlkit-validation-run",
+ "xbrlkit-xbrl-contexts",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-cockpit-export"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "receipt-types",
+ "serde_json",
 ]
 
 [[package]]
@@ -2310,15 +2032,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "xbrlkit-context-completeness"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "xbrlkit-xbrl-contexts",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
 name = "xbrlkit-core"
 version = "0.1.0-alpha.1"
 dependencies = [
- "diff-run",
- "export-run",
  "receipt-types",
- "sec-profile-types",
- "validation-run",
- "xbrl-report-types",
+ "xbrlkit-diff-run",
+ "xbrlkit-export-run",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-validation-run",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-diff-run"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "receipt-types",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-dimensional-rules"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "xbrlkit-taxonomy-dimensions",
+ "xbrlkit-xbrl-contexts",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-duplicate-facts"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-edgar-attachments"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "edgar-identity",
+ "serde",
+]
+
+[[package]]
+name = "xbrlkit-edgar-sgml"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "edgar-identity",
+]
+
+[[package]]
+name = "xbrlkit-efm-rules"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "ixhtml-scan",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-taxonomy-dts",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-export-run"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "receipt-types",
+ "serde_json",
+ "xbrlkit-oim-normalize",
+ "xbrlkit-xbrl-report-types",
 ]
 
 [[package]]
@@ -2326,10 +2117,19 @@ name = "xbrlkit-feature-grid"
 version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
- "scenario-contract",
  "serde",
  "serde_yaml",
  "walkdir",
+ "xbrlkit-scenario-contract",
+]
+
+[[package]]
+name = "xbrlkit-filing-load"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "receipt-types",
+ "xbrlkit-edgar-attachments",
+ "xbrlkit-edgar-sgml",
 ]
 
 [[package]]
@@ -2340,11 +2140,211 @@ dependencies = [
 ]
 
 [[package]]
+name = "xbrlkit-ixds-assemble"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "ixhtml-scan",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-numeric-rules"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-oim-normalize"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "serde_json",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-oracle-compare"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "receipt-types",
+]
+
+[[package]]
+name = "xbrlkit-render-json"
+version = "0.1.0-alpha.1"
+
+[[package]]
+name = "xbrlkit-render-md"
+version = "0.1.0-alpha.1"
+
+[[package]]
+name = "xbrlkit-scenario-contract"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "xbrlkit-scenario-runner"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "receipt-types",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "xbrlkit-export-run",
+ "xbrlkit-scenario-contract",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-validation-run",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-sec-http"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "xbrlkit-sec-profile-types"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_yaml",
+ "xbrlkit-taxonomy-types",
+]
+
+[[package]]
+name = "xbrlkit-taxonomy-cache"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "xbrlkit-taxonomy-dimensions"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "xbrlkit-taxonomy-dts"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-taxonomy-types",
+]
+
+[[package]]
+name = "xbrlkit-taxonomy-loader"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "reqwest",
+ "roxmltree",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "xbrlkit-taxonomy-dimensions",
+]
+
+[[package]]
+name = "xbrlkit-taxonomy-package"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "xbrlkit-taxonomy-types",
+]
+
+[[package]]
+name = "xbrlkit-taxonomy-types"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "xbrlkit-test-grid"
 version = "0.1.0-alpha.1"
 dependencies = [
- "scenario-contract",
+ "xbrlkit-scenario-contract",
 ]
+
+[[package]]
+name = "xbrlkit-unit-rules"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "regex",
+ "serde",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-validation-run"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "receipt-types",
+ "xbrlkit-context-completeness",
+ "xbrlkit-dimensional-rules",
+ "xbrlkit-duplicate-facts",
+ "xbrlkit-efm-rules",
+ "xbrlkit-ixds-assemble",
+ "xbrlkit-numeric-rules",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-taxonomy-dimensions",
+ "xbrlkit-taxonomy-dts",
+ "xbrlkit-taxonomy-types",
+ "xbrlkit-xbrl-contexts",
+ "xbrlkit-xbrl-report-types",
+ "xbrlkit-xbrl-stream",
+]
+
+[[package]]
+name = "xbrlkit-xbrl-contexts"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "roxmltree",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "xbrlkit-xbrl-dimensions"
+version = "0.1.0-alpha.1"
+
+[[package]]
+name = "xbrlkit-xbrl-linkbases"
+version = "0.1.0-alpha.1"
+
+[[package]]
+name = "xbrlkit-xbrl-report-types"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "xbrlkit-xbrl-stream"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "anyhow",
+ "quick-xml",
+ "thiserror 1.0.69",
+ "tokio",
+ "xbrlkit-xbrl-report-types",
+]
+
+[[package]]
+name = "xbrlkit-xbrl-units"
+version = "0.1.0-alpha.1"
 
 [[package]]
 name = "xtask"
@@ -2353,19 +2353,19 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "cockpit-export",
  "receipt-types",
- "scenario-contract",
- "scenario-runner",
- "sec-profile-types",
  "serde",
  "serde_json",
  "serde_yaml",
- "validation-run",
  "walkdir",
- "xbrl-report-types",
  "xbrlkit-bdd",
+ "xbrlkit-cockpit-export",
  "xbrlkit-feature-grid",
+ "xbrlkit-scenario-contract",
+ "xbrlkit-scenario-runner",
+ "xbrlkit-sec-profile-types",
+ "xbrlkit-validation-run",
+ "xbrlkit-xbrl-report-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,44 +73,44 @@ tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "sync"] }
 walkdir = "2.5.0"
 archive-zip = { version = "0.1.0-alpha.1", path = "crates/archive-zip" }
 calc11 = { version = "0.1.0-alpha.1", path = "crates/calc11" }
-cockpit-export = { version = "0.1.0-alpha.1", path = "crates/cockpit-export" }
-context-completeness = { version = "0.1.0-alpha.1", path = "crates/context-completeness" }
+cockpit-export = { package = "xbrlkit-cockpit-export", version = "0.1.0-alpha.1", path = "crates/cockpit-export" }
+context-completeness = { package = "xbrlkit-context-completeness", version = "0.1.0-alpha.1", path = "crates/context-completeness" }
 corpus-fs = { version = "0.1.0-alpha.1", path = "crates/corpus-fs" }
-diff-run = { version = "0.1.0-alpha.1", path = "crates/diff-run" }
-dimensional-rules = { version = "0.1.0-alpha.1", path = "crates/dimensional-rules" }
-duplicate-facts = { version = "0.1.0-alpha.1", path = "crates/duplicate-facts" }
-edgar-attachments = { version = "0.1.0-alpha.1", path = "crates/edgar-attachments" }
+diff-run = { package = "xbrlkit-diff-run", version = "0.1.0-alpha.1", path = "crates/diff-run" }
+dimensional-rules = { package = "xbrlkit-dimensional-rules", version = "0.1.0-alpha.1", path = "crates/dimensional-rules" }
+duplicate-facts = { package = "xbrlkit-duplicate-facts", version = "0.1.0-alpha.1", path = "crates/duplicate-facts" }
+edgar-attachments = { package = "xbrlkit-edgar-attachments", version = "0.1.0-alpha.1", path = "crates/edgar-attachments" }
 edgar-identity = { version = "0.1.0-alpha.1", path = "crates/edgar-identity" }
-edgar-sgml = { version = "0.1.0-alpha.1", path = "crates/edgar-sgml" }
-efm-rules = { version = "0.1.0-alpha.1", path = "crates/efm-rules" }
-export-run = { version = "0.1.0-alpha.1", path = "crates/export-run" }
-filing-load = { version = "0.1.0-alpha.1", path = "crates/filing-load" }
-ixds-assemble = { version = "0.1.0-alpha.1", path = "crates/ixds-assemble" }
+edgar-sgml = { package = "xbrlkit-edgar-sgml", version = "0.1.0-alpha.1", path = "crates/edgar-sgml" }
+efm-rules = { package = "xbrlkit-efm-rules", version = "0.1.0-alpha.1", path = "crates/efm-rules" }
+export-run = { package = "xbrlkit-export-run", version = "0.1.0-alpha.1", path = "crates/export-run" }
+filing-load = { package = "xbrlkit-filing-load", version = "0.1.0-alpha.1", path = "crates/filing-load" }
+ixds-assemble = { package = "xbrlkit-ixds-assemble", version = "0.1.0-alpha.1", path = "crates/ixds-assemble" }
 ixhtml-scan = { version = "0.1.0-alpha.1", path = "crates/ixhtml-scan" }
-numeric-rules = { version = "0.1.0-alpha.1", path = "crates/numeric-rules" }
-oim-normalize = { version = "0.1.0-alpha.1", path = "crates/oim-normalize" }
-oracle-compare = { version = "0.1.0-alpha.1", path = "crates/oracle-compare" }
+numeric-rules = { package = "xbrlkit-numeric-rules", version = "0.1.0-alpha.1", path = "crates/numeric-rules" }
+oim-normalize = { package = "xbrlkit-oim-normalize", version = "0.1.0-alpha.1", path = "crates/oim-normalize" }
+oracle-compare = { package = "xbrlkit-oracle-compare", version = "0.1.0-alpha.1", path = "crates/oracle-compare" }
 receipt-types = { version = "0.1.0-alpha.1", path = "crates/receipt-types" }
-render-json = { version = "0.1.0-alpha.1", path = "crates/render-json" }
-render-md = { version = "0.1.0-alpha.1", path = "crates/render-md" }
-scenario-contract = { version = "0.1.0-alpha.1", path = "crates/scenario-contract" }
-scenario-runner = { version = "0.1.0-alpha.1", path = "crates/scenario-runner" }
-sec-http = { version = "0.1.0-alpha.1", path = "crates/sec-http" }
-sec-profile-types = { version = "0.1.0-alpha.1", path = "crates/sec-profile-types" }
-taxonomy-cache = { version = "0.1.0-alpha.1", path = "crates/taxonomy-cache" }
-taxonomy-dimensions = { version = "0.1.0-alpha.1", path = "crates/taxonomy-dimensions" }
-taxonomy-dts = { version = "0.1.0-alpha.1", path = "crates/taxonomy-dts" }
-taxonomy-loader = { version = "0.1.0-alpha.1", path = "crates/taxonomy-loader" }
-taxonomy-package = { version = "0.1.0-alpha.1", path = "crates/taxonomy-package" }
-taxonomy-types = { version = "0.1.0-alpha.1", path = "crates/taxonomy-types" }
-unit-rules = { version = "0.1.0-alpha.1", path = "crates/unit-rules" }
-validation-run = { version = "0.1.0-alpha.1", path = "crates/validation-run" }
-xbrl-contexts = { version = "0.1.0-alpha.1", path = "crates/xbrl-contexts" }
-xbrl-dimensions = { version = "0.1.0-alpha.1", path = "crates/xbrl-dimensions" }
-xbrl-linkbases = { version = "0.1.0-alpha.1", path = "crates/xbrl-linkbases" }
-xbrl-report-types = { version = "0.1.0-alpha.1", path = "crates/xbrl-report-types" }
-xbrl-stream = { version = "0.1.0-alpha.1", path = "crates/xbrl-stream" }
-xbrl-units = { version = "0.1.0-alpha.1", path = "crates/xbrl-units" }
+render-json = { package = "xbrlkit-render-json", version = "0.1.0-alpha.1", path = "crates/render-json" }
+render-md = { package = "xbrlkit-render-md", version = "0.1.0-alpha.1", path = "crates/render-md" }
+scenario-contract = { package = "xbrlkit-scenario-contract", version = "0.1.0-alpha.1", path = "crates/scenario-contract" }
+scenario-runner = { package = "xbrlkit-scenario-runner", version = "0.1.0-alpha.1", path = "crates/scenario-runner" }
+sec-http = { package = "xbrlkit-sec-http", version = "0.1.0-alpha.1", path = "crates/sec-http" }
+sec-profile-types = { package = "xbrlkit-sec-profile-types", version = "0.1.0-alpha.1", path = "crates/sec-profile-types" }
+taxonomy-cache = { package = "xbrlkit-taxonomy-cache", version = "0.1.0-alpha.1", path = "crates/taxonomy-cache" }
+taxonomy-dimensions = { package = "xbrlkit-taxonomy-dimensions", version = "0.1.0-alpha.1", path = "crates/taxonomy-dimensions" }
+taxonomy-dts = { package = "xbrlkit-taxonomy-dts", version = "0.1.0-alpha.1", path = "crates/taxonomy-dts" }
+taxonomy-loader = { package = "xbrlkit-taxonomy-loader", version = "0.1.0-alpha.1", path = "crates/taxonomy-loader" }
+taxonomy-package = { package = "xbrlkit-taxonomy-package", version = "0.1.0-alpha.1", path = "crates/taxonomy-package" }
+taxonomy-types = { package = "xbrlkit-taxonomy-types", version = "0.1.0-alpha.1", path = "crates/taxonomy-types" }
+unit-rules = { package = "xbrlkit-unit-rules", version = "0.1.0-alpha.1", path = "crates/unit-rules" }
+validation-run = { package = "xbrlkit-validation-run", version = "0.1.0-alpha.1", path = "crates/validation-run" }
+xbrl-contexts = { package = "xbrlkit-xbrl-contexts", version = "0.1.0-alpha.1", path = "crates/xbrl-contexts" }
+xbrl-dimensions = { package = "xbrlkit-xbrl-dimensions", version = "0.1.0-alpha.1", path = "crates/xbrl-dimensions" }
+xbrl-linkbases = { package = "xbrlkit-xbrl-linkbases", version = "0.1.0-alpha.1", path = "crates/xbrl-linkbases" }
+xbrl-report-types = { package = "xbrlkit-xbrl-report-types", version = "0.1.0-alpha.1", path = "crates/xbrl-report-types" }
+xbrl-stream = { package = "xbrlkit-xbrl-stream", version = "0.1.0-alpha.1", path = "crates/xbrl-stream" }
+xbrl-units = { package = "xbrlkit-xbrl-units", version = "0.1.0-alpha.1", path = "crates/xbrl-units" }
 xbrlkit-bdd = { version = "0.1.0-alpha.1", path = "crates/xbrlkit-bdd" }
 xbrlkit-bdd-steps = { version = "0.1.0-alpha.1", path = "crates/xbrlkit-bdd-steps" }
 xbrlkit-cli = { version = "0.1.0-alpha.1", path = "crates/xbrlkit-cli" }

--- a/crates/cockpit-export/Cargo.toml
+++ b/crates/cockpit-export/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cockpit-export"
+name = "xbrlkit-cockpit-export"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cockpit-export/README.md
+++ b/crates/cockpit-export/README.md
@@ -1,4 +1,4 @@
-# cockpit-export
+# xbrlkit-cockpit-export
 
 Cockpit dashboard export utilities.
 
@@ -6,7 +6,7 @@ Cockpit dashboard export utilities.
 
 ```toml
 [dependencies]
-cockpit-export = "0.1.0-alpha.1"
+xbrlkit-cockpit-export = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/context-completeness/Cargo.toml
+++ b/crates/context-completeness/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "context-completeness"
+name = "xbrlkit-context-completeness"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/context-completeness/README.md
+++ b/crates/context-completeness/README.md
@@ -1,4 +1,4 @@
-# context-completeness
+# xbrlkit-context-completeness
 
 XBRL context completeness validation.
 
@@ -6,7 +6,7 @@ XBRL context completeness validation.
 
 ```toml
 [dependencies]
-context-completeness = "0.1.0-alpha.1"
+xbrlkit-context-completeness = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/diff-run/Cargo.toml
+++ b/crates/diff-run/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "diff-run"
+name = "xbrlkit-diff-run"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/diff-run/README.md
+++ b/crates/diff-run/README.md
@@ -1,4 +1,4 @@
-# diff-run
+# xbrlkit-diff-run
 
 XBRL receipt comparison and diffing.
 
@@ -6,7 +6,7 @@ XBRL receipt comparison and diffing.
 
 ```toml
 [dependencies]
-diff-run = "0.1.0-alpha.1"
+xbrlkit-diff-run = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/dimensional-rules/Cargo.toml
+++ b/crates/dimensional-rules/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dimensional-rules"
+name = "xbrlkit-dimensional-rules"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/dimensional-rules/README.md
+++ b/crates/dimensional-rules/README.md
@@ -1,4 +1,4 @@
-# dimensional-rules
+# xbrlkit-dimensional-rules
 
 Dimensional validation rules for XBRL.
 
@@ -6,7 +6,7 @@ Dimensional validation rules for XBRL.
 
 ```toml
 [dependencies]
-dimensional-rules = "0.1.0-alpha.1"
+xbrlkit-dimensional-rules = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/duplicate-facts/Cargo.toml
+++ b/crates/duplicate-facts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "duplicate-facts"
+name = "xbrlkit-duplicate-facts"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/duplicate-facts/README.md
+++ b/crates/duplicate-facts/README.md
@@ -1,4 +1,4 @@
-# duplicate-facts
+# xbrlkit-duplicate-facts
 
 Duplicate fact detection for XBRL reports.
 
@@ -6,7 +6,7 @@ Duplicate fact detection for XBRL reports.
 
 ```toml
 [dependencies]
-duplicate-facts = "0.1.0-alpha.1"
+xbrlkit-duplicate-facts = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/edgar-attachments/Cargo.toml
+++ b/crates/edgar-attachments/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edgar-attachments"
+name = "xbrlkit-edgar-attachments"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/edgar-attachments/README.md
+++ b/crates/edgar-attachments/README.md
@@ -1,4 +1,4 @@
-# edgar-attachments
+# xbrlkit-edgar-attachments
 
 EDGAR filing attachment handling.
 
@@ -6,7 +6,7 @@ EDGAR filing attachment handling.
 
 ```toml
 [dependencies]
-edgar-attachments = "0.1.0-alpha.1"
+xbrlkit-edgar-attachments = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/edgar-sgml/Cargo.toml
+++ b/crates/edgar-sgml/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "edgar-sgml"
+name = "xbrlkit-edgar-sgml"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/edgar-sgml/README.md
+++ b/crates/edgar-sgml/README.md
@@ -1,4 +1,4 @@
-# edgar-sgml
+# xbrlkit-edgar-sgml
 
 EDGAR SGML filing parser.
 
@@ -6,7 +6,7 @@ EDGAR SGML filing parser.
 
 ```toml
 [dependencies]
-edgar-sgml = "0.1.0-alpha.1"
+xbrlkit-edgar-sgml = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/efm-rules/Cargo.toml
+++ b/crates/efm-rules/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "efm-rules"
+name = "xbrlkit-efm-rules"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/efm-rules/README.md
+++ b/crates/efm-rules/README.md
@@ -1,4 +1,4 @@
-# efm-rules
+# xbrlkit-efm-rules
 
 EFM (Electronic Filing Manual) validation rules.
 
@@ -6,7 +6,7 @@ EFM (Electronic Filing Manual) validation rules.
 
 ```toml
 [dependencies]
-efm-rules = "0.1.0-alpha.1"
+xbrlkit-efm-rules = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/export-run/Cargo.toml
+++ b/crates/export-run/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "export-run"
+name = "xbrlkit-export-run"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/export-run/README.md
+++ b/crates/export-run/README.md
@@ -1,4 +1,4 @@
-# export-run
+# xbrlkit-export-run
 
 XBRL report export and serialization.
 
@@ -6,7 +6,7 @@ XBRL report export and serialization.
 
 ```toml
 [dependencies]
-export-run = "0.1.0-alpha.1"
+xbrlkit-export-run = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/filing-load/Cargo.toml
+++ b/crates/filing-load/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "filing-load"
+name = "xbrlkit-filing-load"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/filing-load/README.md
+++ b/crates/filing-load/README.md
@@ -1,4 +1,4 @@
-# filing-load
+# xbrlkit-filing-load
 
 EDGAR filing loader combining SGML and attachments.
 
@@ -6,7 +6,7 @@ EDGAR filing loader combining SGML and attachments.
 
 ```toml
 [dependencies]
-filing-load = "0.1.0-alpha.1"
+xbrlkit-filing-load = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/ixds-assemble/Cargo.toml
+++ b/crates/ixds-assemble/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ixds-assemble"
+name = "xbrlkit-ixds-assemble"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/ixds-assemble/README.md
+++ b/crates/ixds-assemble/README.md
@@ -1,4 +1,4 @@
-# ixds-assemble
+# xbrlkit-ixds-assemble
 
 Inline XBRL Dataset assembly from documents.
 
@@ -6,7 +6,7 @@ Inline XBRL Dataset assembly from documents.
 
 ```toml
 [dependencies]
-ixds-assemble = "0.1.0-alpha.1"
+xbrlkit-ixds-assemble = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/numeric-rules/Cargo.toml
+++ b/crates/numeric-rules/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "numeric-rules"
+name = "xbrlkit-numeric-rules"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/numeric-rules/README.md
+++ b/crates/numeric-rules/README.md
@@ -1,4 +1,4 @@
-# numeric-rules
+# xbrlkit-numeric-rules
 
 Numeric validation rules for XBRL reports.
 
@@ -6,7 +6,7 @@ Numeric validation rules for XBRL reports.
 
 ```toml
 [dependencies]
-numeric-rules = "0.1.0-alpha.1"
+xbrlkit-numeric-rules = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/oim-normalize/Cargo.toml
+++ b/crates/oim-normalize/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oim-normalize"
+name = "xbrlkit-oim-normalize"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/oim-normalize/README.md
+++ b/crates/oim-normalize/README.md
@@ -1,4 +1,4 @@
-# oim-normalize
+# xbrlkit-oim-normalize
 
 Open Information Model (OIM) normalization.
 
@@ -6,7 +6,7 @@ Open Information Model (OIM) normalization.
 
 ```toml
 [dependencies]
-oim-normalize = "0.1.0-alpha.1"
+xbrlkit-oim-normalize = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/oracle-compare/Cargo.toml
+++ b/crates/oracle-compare/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oracle-compare"
+name = "xbrlkit-oracle-compare"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/oracle-compare/README.md
+++ b/crates/oracle-compare/README.md
@@ -1,4 +1,4 @@
-# oracle-compare
+# xbrlkit-oracle-compare
 
 Oracle XBRL comparison utilities.
 
@@ -6,7 +6,7 @@ Oracle XBRL comparison utilities.
 
 ```toml
 [dependencies]
-oracle-compare = "0.1.0-alpha.1"
+xbrlkit-oracle-compare = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/render-json/Cargo.toml
+++ b/crates/render-json/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "render-json"
+name = "xbrlkit-render-json"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/render-json/README.md
+++ b/crates/render-json/README.md
@@ -1,4 +1,4 @@
-# render-json
+# xbrlkit-render-json
 
 JSON rendering for XBRL reports.
 
@@ -6,7 +6,7 @@ JSON rendering for XBRL reports.
 
 ```toml
 [dependencies]
-render-json = "0.1.0-alpha.1"
+xbrlkit-render-json = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/render-md/Cargo.toml
+++ b/crates/render-md/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "render-md"
+name = "xbrlkit-render-md"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/render-md/README.md
+++ b/crates/render-md/README.md
@@ -1,4 +1,4 @@
-# render-md
+# xbrlkit-render-md
 
 Markdown rendering for XBRL reports.
 
@@ -6,7 +6,7 @@ Markdown rendering for XBRL reports.
 
 ```toml
 [dependencies]
-render-md = "0.1.0-alpha.1"
+xbrlkit-render-md = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/scenario-contract/Cargo.toml
+++ b/crates/scenario-contract/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scenario-contract"
+name = "xbrlkit-scenario-contract"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/scenario-contract/README.md
+++ b/crates/scenario-contract/README.md
@@ -1,4 +1,4 @@
-# scenario-contract
+# xbrlkit-scenario-contract
 
 Scenario grid and bundle contracts for xbrlkit.
 
@@ -6,7 +6,7 @@ Scenario grid and bundle contracts for xbrlkit.
 
 ```toml
 [dependencies]
-scenario-contract = "0.1.0-alpha.1"
+xbrlkit-scenario-contract = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/scenario-runner/Cargo.toml
+++ b/crates/scenario-runner/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "scenario-runner"
+name = "xbrlkit-scenario-runner"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/sec-http/Cargo.toml
+++ b/crates/sec-http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sec-http"
+name = "xbrlkit-sec-http"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/sec-http/README.md
+++ b/crates/sec-http/README.md
@@ -1,4 +1,4 @@
-# sec-http
+# xbrlkit-sec-http
 
 HTTP client utilities for SEC EDGAR API access.
 
@@ -6,7 +6,7 @@ HTTP client utilities for SEC EDGAR API access.
 
 ```toml
 [dependencies]
-sec-http = "0.1.0-alpha.1"
+xbrlkit-sec-http = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/sec-profile-types/Cargo.toml
+++ b/crates/sec-profile-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sec-profile-types"
+name = "xbrlkit-sec-profile-types"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/sec-profile-types/README.md
+++ b/crates/sec-profile-types/README.md
@@ -1,4 +1,4 @@
-# sec-profile-types
+# xbrlkit-sec-profile-types
 
 SEC profile pack DTOs for EDGAR validation.
 
@@ -6,7 +6,7 @@ SEC profile pack DTOs for EDGAR validation.
 
 ```toml
 [dependencies]
-sec-profile-types = "0.1.0-alpha.1"
+xbrlkit-sec-profile-types = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-cache/Cargo.toml
+++ b/crates/taxonomy-cache/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taxonomy-cache"
+name = "xbrlkit-taxonomy-cache"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/taxonomy-cache/README.md
+++ b/crates/taxonomy-cache/README.md
@@ -1,4 +1,4 @@
-# taxonomy-cache
+# xbrlkit-taxonomy-cache
 
 Taxonomy caching and indexing.
 
@@ -6,7 +6,7 @@ Taxonomy caching and indexing.
 
 ```toml
 [dependencies]
-taxonomy-cache = "0.1.0-alpha.1"
+xbrlkit-taxonomy-cache = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-dimensions/Cargo.toml
+++ b/crates/taxonomy-dimensions/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taxonomy-dimensions"
+name = "xbrlkit-taxonomy-dimensions"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/taxonomy-dimensions/README.md
+++ b/crates/taxonomy-dimensions/README.md
@@ -1,4 +1,4 @@
-# taxonomy-dimensions
+# xbrlkit-taxonomy-dimensions
 
 Taxonomy dimension definitions and validation.
 
@@ -6,7 +6,7 @@ Taxonomy dimension definitions and validation.
 
 ```toml
 [dependencies]
-taxonomy-dimensions = "0.1.0-alpha.1"
+xbrlkit-taxonomy-dimensions = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-dts/Cargo.toml
+++ b/crates/taxonomy-dts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taxonomy-dts"
+name = "xbrlkit-taxonomy-dts"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/taxonomy-dts/README.md
+++ b/crates/taxonomy-dts/README.md
@@ -1,4 +1,4 @@
-# taxonomy-dts
+# xbrlkit-taxonomy-dts
 
 Discoverable Taxonomy Set (DTS) processing.
 
@@ -6,7 +6,7 @@ Discoverable Taxonomy Set (DTS) processing.
 
 ```toml
 [dependencies]
-taxonomy-dts = "0.1.0-alpha.1"
+xbrlkit-taxonomy-dts = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-loader/Cargo.toml
+++ b/crates/taxonomy-loader/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taxonomy-loader"
+name = "xbrlkit-taxonomy-loader"
 edition.workspace = true
 version.workspace = true
 license.workspace = true

--- a/crates/taxonomy-loader/README.md
+++ b/crates/taxonomy-loader/README.md
@@ -1,4 +1,4 @@
-# taxonomy-loader
+# xbrlkit-taxonomy-loader
 
 XBRL taxonomy loading from XSD and linkbase files.
 
@@ -6,7 +6,7 @@ XBRL taxonomy loading from XSD and linkbase files.
 
 ```toml
 [dependencies]
-taxonomy-loader = "0.1.0-alpha.1"
+xbrlkit-taxonomy-loader = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-package/Cargo.toml
+++ b/crates/taxonomy-package/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taxonomy-package"
+name = "xbrlkit-taxonomy-package"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/taxonomy-package/README.md
+++ b/crates/taxonomy-package/README.md
@@ -1,4 +1,4 @@
-# taxonomy-package
+# xbrlkit-taxonomy-package
 
 Taxonomy package loading and management.
 
@@ -6,7 +6,7 @@ Taxonomy package loading and management.
 
 ```toml
 [dependencies]
-taxonomy-package = "0.1.0-alpha.1"
+xbrlkit-taxonomy-package = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/taxonomy-types/Cargo.toml
+++ b/crates/taxonomy-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taxonomy-types"
+name = "xbrlkit-taxonomy-types"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/taxonomy-types/README.md
+++ b/crates/taxonomy-types/README.md
@@ -1,4 +1,4 @@
-# taxonomy-types
+# xbrlkit-taxonomy-types
 
 Taxonomy DTOs for XBRL taxonomy processing.
 
@@ -6,7 +6,7 @@ Taxonomy DTOs for XBRL taxonomy processing.
 
 ```toml
 [dependencies]
-taxonomy-types = "0.1.0-alpha.1"
+xbrlkit-taxonomy-types = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/unit-rules/Cargo.toml
+++ b/crates/unit-rules/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "unit-rules"
+name = "xbrlkit-unit-rules"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/unit-rules/README.md
+++ b/crates/unit-rules/README.md
@@ -1,4 +1,4 @@
-# unit-rules
+# xbrlkit-unit-rules
 
 XBRL unit consistency validation rules.
 
@@ -6,7 +6,7 @@ XBRL unit consistency validation rules.
 
 ```toml
 [dependencies]
-unit-rules = "0.1.0-alpha.1"
+xbrlkit-unit-rules = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/validation-run/Cargo.toml
+++ b/crates/validation-run/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "validation-run"
+name = "xbrlkit-validation-run"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/validation-run/README.md
+++ b/crates/validation-run/README.md
@@ -1,4 +1,4 @@
-# validation-run
+# xbrlkit-validation-run
 
 XBRL validation orchestration and execution.
 
@@ -6,7 +6,7 @@ XBRL validation orchestration and execution.
 
 ```toml
 [dependencies]
-validation-run = "0.1.0-alpha.1"
+xbrlkit-validation-run = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-contexts/Cargo.toml
+++ b/crates/xbrl-contexts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xbrl-contexts"
+name = "xbrlkit-xbrl-contexts"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/xbrl-contexts/README.md
+++ b/crates/xbrl-contexts/README.md
@@ -1,4 +1,4 @@
-# xbrl-contexts
+# xbrlkit-xbrl-contexts
 
 XBRL context and entity parsing.
 
@@ -6,7 +6,7 @@ XBRL context and entity parsing.
 
 ```toml
 [dependencies]
-xbrl-contexts = "0.1.0-alpha.1"
+xbrlkit-xbrl-contexts = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-dimensions/Cargo.toml
+++ b/crates/xbrl-dimensions/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xbrl-dimensions"
+name = "xbrlkit-xbrl-dimensions"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/xbrl-dimensions/README.md
+++ b/crates/xbrl-dimensions/README.md
@@ -1,4 +1,4 @@
-# xbrl-dimensions
+# xbrlkit-xbrl-dimensions
 
 XBRL dimensional parsing and structures.
 
@@ -6,7 +6,7 @@ XBRL dimensional parsing and structures.
 
 ```toml
 [dependencies]
-xbrl-dimensions = "0.1.0-alpha.1"
+xbrlkit-xbrl-dimensions = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-linkbases/Cargo.toml
+++ b/crates/xbrl-linkbases/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xbrl-linkbases"
+name = "xbrlkit-xbrl-linkbases"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/xbrl-linkbases/README.md
+++ b/crates/xbrl-linkbases/README.md
@@ -1,4 +1,4 @@
-# xbrl-linkbases
+# xbrlkit-xbrl-linkbases
 
 XBRL linkbase parsing (premium, label, reference).
 
@@ -6,7 +6,7 @@ XBRL linkbase parsing (premium, label, reference).
 
 ```toml
 [dependencies]
-xbrl-linkbases = "0.1.0-alpha.1"
+xbrlkit-xbrl-linkbases = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-report-types/Cargo.toml
+++ b/crates/xbrl-report-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xbrl-report-types"
+name = "xbrlkit-xbrl-report-types"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/xbrl-report-types/README.md
+++ b/crates/xbrl-report-types/README.md
@@ -1,4 +1,4 @@
-# xbrl-report-types
+# xbrlkit-xbrl-report-types
 
 XBRL report data types and structures.
 
@@ -6,7 +6,7 @@ XBRL report data types and structures.
 
 ```toml
 [dependencies]
-xbrl-report-types = "0.1.0-alpha.1"
+xbrlkit-xbrl-report-types = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-stream/Cargo.toml
+++ b/crates/xbrl-stream/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xbrl-stream"
+name = "xbrlkit-xbrl-stream"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/xbrl-stream/README.md
+++ b/crates/xbrl-stream/README.md
@@ -1,4 +1,4 @@
-# xbrl-stream
+# xbrlkit-xbrl-stream
 
 SAX-style streaming XBRL parser for large filings.
 
@@ -6,7 +6,7 @@ SAX-style streaming XBRL parser for large filings.
 
 ```toml
 [dependencies]
-xbrl-stream = "0.1.0-alpha.1"
+xbrlkit-xbrl-stream = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.

--- a/crates/xbrl-units/Cargo.toml
+++ b/crates/xbrl-units/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xbrl-units"
+name = "xbrlkit-xbrl-units"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/xbrl-units/README.md
+++ b/crates/xbrl-units/README.md
@@ -1,4 +1,4 @@
-# xbrl-units
+# xbrlkit-xbrl-units
 
 XBRL unit definitions and validation.
 
@@ -6,7 +6,7 @@ XBRL unit definitions and validation.
 
 ```toml
 [dependencies]
-xbrl-units = "0.1.0-alpha.1"
+xbrlkit-xbrl-units = "0.1.0-alpha.1"
 ```
 
 See [xbrlkit](https://github.com/EffortlessMetrics/xbrlkit) for more.


### PR DESCRIPTION
## Summary
- rename 34 unpublished workspace package names to `xbrlkit-*`
- preserve the six crates already published from this repo under their existing names: `archive-zip`, `calc11`, `corpus-fs`, `edgar-identity`, `ixhtml-scan`, and `receipt-types`
- keep internal workspace dependency aliases stable by adding `package = "xbrlkit-*"` entries in the root workspace manifest
- update affected README dependency snippets and refresh `Cargo.lock` for the new package IDs
- leave `xtask` unchanged because this workspace crate is `publish = false`; the crates.io `xtask` package is unrelated

## Verification
- queried crates.io package metadata on March 31, 2026 to distinguish already-published repo crates from unpublished ones
- `cargo check --workspace`