### PR TITLE
[FR-011] Fix dimensional-rules unwrap panic risk

### DIFF
--- a/crates/dimensional-rules/src/lib.rs
+++ b/crates/dimensional-rules/src/lib.rs
@@ -145,8 +145,8 @@ fn validate_dimension_member(
     dim_member: &DimensionMember,
     dim_taxonomy: &DimensionTaxonomy,
 ) -> Result<(), ValidationFinding> {
-    // Check if dimension exists
-    if !dim_taxonomy.dimensions.contains_key(&dim_member.dimension) {
+    // Get the dimension definition (if it exists)
+    let Some(dimension) = dim_taxonomy.dimensions.get(&dim_member.dimension) else {
         return Err(ValidationFinding {
             rule_id: "XBRL.DIMENSION.UNKNOWN".to_string(),
             severity: "error".to_string(),
@@ -154,10 +154,7 @@ fn validate_dimension_member(
             member: Some(dim_member.dimension.clone()),
             subject: Some(dim_member.member.clone()),
         });
-    }
-
-    // Get the dimension definition
-    let dimension = dim_taxonomy.dimensions.get(&dim_member.dimension).unwrap();
+    };
 
     // If it's a typed dimension, validate the value against the expected type
     if dimension.is_typed() {


### PR DESCRIPTION
## Summary

Fixes #154 - Removes the panic risk from  in the dimensional-rules crate.

## Changes

- Replaced  pattern with  pattern
- This eliminates the potential panic risk (FR-011) and makes the code more idiomatic

## Quality Checks

- ✅  - Passed
- ✅  - Passed  
- ✅  - 17 tests passed

## Related

- Issue: #154
- Risk Level: Low (refactoring only, no functional changes)