### PR TITLE
fix(fixture): add HTML member for manifest check scenario

### DIFF
--- a/fixtures/synthetic/filing/minimal-container-01/member-a.html
+++ b/fixtures/synthetic/filing/minimal-container-01/member-a.html
@@ -1,0 +1,7 @@
+<html xmlns:ix="http://xbrl.org/2013/inlineXBRL" xmlns:dei="http://xbrl.sec.gov/dei/2024"><body>
+<ix:nonNumeric name="dei:EntityRegistrantName">Example Corp</ix:nonNumeric>
+<ix:nonNumeric name="dei:DocumentType">10-K</ix:nonNumeric>
+<ix:nonNumeric name="dei:DocumentPeriodEndDate">2024-12-31</ix:nonNumeric>
+<ix:nonNumeric name="dei:AmendmentFlag">false</ix:nonNumeric>
+<ix:nonNumeric name="dei:EntityCentralIndexKey">0001234567</ix:nonNumeric>
+</body></html>


### PR DESCRIPTION
Adds minimal inline XBRL HTML fixture to `synthetic/filing/minimal-container-01/` so AC-XK-MANIFEST-001 alpha-check can find HTML members.

Closes #236.
Unblocks #134.