### PR TITLE
refactor(scenario-contract): move selector matching logic to scenario_contract crate

### DIFF
--- a/crates/scenario-contract/src/lib.rs
+++ b/crates/scenario-contract/src/lib.rs
@@ -44,3 +44,113 @@ pub struct ImpactReport {
     #[serde(default)]
     pub impacted_scenarios: Vec<String>,
 }
+
+impl ScenarioRecord {
+    /// Check if this scenario matches a selector string.
+    ///
+    /// Supported selector patterns:
+    /// - Bare `scenario_id` (e.g. `SCN-XK-WORKFLOW-002`)
+    /// - `@`-prefixed `scenario_id` (e.g. `@SCN-XK-WORKFLOW-002`)
+    /// - Bare `ac_id` (e.g. `AC-XK-WORKFLOW-002`)
+    /// - `@`-prefixed `ac_id` (e.g. `@AC-XK-WORKFLOW-002`)
+    /// - Bare `req_id` (e.g. `REQ-XK-WORKFLOW`)
+    pub fn matches_selector(&self, selector: &str) -> bool {
+        self.scenario_id == selector
+            || self.ac_id.as_deref() == Some(selector)
+            || self.req_id.as_deref() == Some(selector)
+            || format!("@{}", self.scenario_id) == selector
+            || self
+                .ac_id
+                .as_ref()
+                .is_some_and(|ac| format!("@{ac}") == selector)
+    }
+}
+
+impl FeatureGrid {
+    /// Select all scenarios matching the given selector.
+    pub fn select_by_selector(&self, selector: &str) -> Vec<ScenarioRecord> {
+        self.scenarios
+            .iter()
+            .filter(|s| s.matches_selector(selector))
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FeatureGrid, ScenarioRecord};
+
+    fn scenario_record() -> ScenarioRecord {
+        ScenarioRecord {
+            scenario_id: "SCN-XK-WORKFLOW-002".to_string(),
+            ac_id: Some("AC-XK-WORKFLOW-002".to_string()),
+            req_id: Some("REQ-XK-WORKFLOW".to_string()),
+            feature_file: "specs/features/workflow/bundle.feature".to_string(),
+            sidecar_file: "specs/features/workflow/bundle.meta.yaml".to_string(),
+            layer: "workflow".to_string(),
+            module: "bundle".to_string(),
+            crates: vec!["xtask".to_string()],
+            fixtures: Vec::new(),
+            profile_pack: None,
+            receipts: vec!["bundle.manifest.v1".to_string()],
+            allowed_edit_roots: vec![
+                "specs/features/workflow".to_string(),
+                "xtask".to_string(),
+            ],
+            suite: Some("synthetic".to_string()),
+            speed: Some("fast".to_string()),
+        }
+    }
+
+    #[test]
+    fn matches_selector_by_scenario_id() {
+        let scenario = scenario_record();
+        assert!(scenario.matches_selector("SCN-XK-WORKFLOW-002"));
+    }
+
+    #[test]
+    fn matches_selector_by_ac_id() {
+        let scenario = scenario_record();
+        assert!(scenario.matches_selector("AC-XK-WORKFLOW-002"));
+    }
+
+    #[test]
+    fn matches_selector_by_req_id() {
+        let scenario = scenario_record();
+        assert!(scenario.matches_selector("REQ-XK-WORKFLOW"));
+    }
+
+    #[test]
+    fn matches_selector_by_tag_style_scenario_id() {
+        let scenario = scenario_record();
+        assert!(scenario.matches_selector("@SCN-XK-WORKFLOW-002"));
+    }
+
+    #[test]
+    fn matches_selector_by_tag_style_ac_id() {
+        let scenario = scenario_record();
+        assert!(scenario.matches_selector("@AC-XK-WORKFLOW-002"));
+    }
+
+    #[test]
+    fn matches_selector_no_match() {
+        let scenario = scenario_record();
+        assert!(!scenario.matches_selector("AC-XK-DOES-NOT-EXIST"));
+    }
+
+    #[test]
+    fn select_by_selector_returns_all_matching() {
+        let grid = FeatureGrid {
+            scenarios: vec![scenario_record(), scenario_record()],
+        };
+        let matched = grid.select_by_selector("AC-XK-WORKFLOW-002");
+        assert_eq!(matched.len(), 2);
+    }
+
+    #[test]
+    fn select_by_selector_empty_grid() {
+        let grid = FeatureGrid::default();
+        assert!(grid.select_by_selector("AC-XK-WORKFLOW-002").is_empty());
+    }
+}

--- a/crates/xbrlkit-bdd-steps/src/lib.rs
+++ b/crates/xbrlkit-bdd-steps/src/lib.rs
@@ -845,7 +845,7 @@ fn handle_when(world: &mut World, scenario: &ScenarioRecord, step: &Step) -> any
     // Bundle-related When steps
     if let Some(selector) = step.text.strip_prefix("I bundle the selector \"") {
         let selector = selector.trim_end_matches('"').to_string();
-        let scenarios = select_matching_scenarios(&world.grid, &selector);
+        let scenarios = world.grid.select_by_selector(&selector);
         world.bundle_manifest = Some(BundleManifest {
             selector,
             scenarios,
@@ -1603,23 +1603,4 @@ fn parse_count_suffix(step: &str, prefix: &str, noun_stem: &str) -> Option<usize
     if noun == noun_stem { Some(count) } else { None }
 }
 
-/// Select scenarios matching a selector (`scenario_id`, `ac_id`, `req_id`, or tag)
-fn select_matching_scenarios(grid: &FeatureGrid, selector: &str) -> Vec<ScenarioRecord> {
-    grid.scenarios
-        .iter()
-        .filter(|scenario| selector_matches(scenario, selector))
-        .cloned()
-        .collect()
-}
 
-/// Check if a scenario matches the given selector
-fn selector_matches(scenario: &ScenarioRecord, selector: &str) -> bool {
-    scenario.scenario_id == selector
-        || scenario.ac_id.as_deref() == Some(selector)
-        || scenario.req_id.as_deref() == Some(selector)
-        || format!("@{}", scenario.scenario_id) == selector
-        || scenario
-            .ac_id
-            .as_ref()
-            .is_some_and(|ac| format!("@{ac}") == selector)
-}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,7 +112,7 @@ fn doctor() -> anyhow::Result<()> {
 
 fn bundle(selector: &str) -> anyhow::Result<()> {
     let grid = load_grid()?;
-    let scenarios = select_matching_scenarios(&grid, selector);
+    let scenarios = grid.select_by_selector(selector);
     if scenarios.is_empty() {
         anyhow::bail!("bundle: selector matched no scenarios: {selector}");
     }
@@ -150,7 +150,7 @@ fn impact(changed: &[String]) -> anyhow::Result<()> {
 
 fn test_ac(ac_id: &str) -> anyhow::Result<()> {
     let grid = load_grid()?;
-    let scenarios = select_matching_scenarios(&grid, ac_id);
+    let scenarios = grid.select_by_selector(ac_id);
     if scenarios.is_empty() {
         anyhow::bail!("test-ac: selector matched no scenarios: {ac_id}");
     }
@@ -305,25 +305,6 @@ fn sanitize(input: &str) -> String {
         .collect()
 }
 
-fn select_matching_scenarios(grid: &FeatureGrid, selector: &str) -> Vec<ScenarioRecord> {
-    grid.scenarios
-        .iter()
-        .filter(|scenario| selector_matches(scenario, selector))
-        .cloned()
-        .collect()
-}
-
-fn selector_matches(scenario: &ScenarioRecord, selector: &str) -> bool {
-    scenario.scenario_id == selector
-        || scenario.ac_id.as_deref() == Some(selector)
-        || scenario.req_id.as_deref() == Some(selector)
-        || format!("@{}", scenario.scenario_id) == selector
-        || scenario
-            .ac_id
-            .as_ref()
-            .is_some_and(|ac| format!("@{ac}") == selector)
-}
-
 fn normalize_repo_path(path: &str) -> String {
     path.replace('\\', "/").trim_start_matches("./").to_string()
 }
@@ -350,12 +331,11 @@ fn scenario_impacted(scenario: &ScenarioRecord, changed: &[String]) -> bool {
 mod tests {
     use super::{
         CargoMetadataPackage, normalize_repo_path, package_is_publishable, scenario_impacted,
-        select_matching_scenarios,
     };
-    use scenario_contract::{FeatureGrid, ScenarioRecord};
+    use scenario_contract::FeatureGrid;
 
-    fn scenario_record() -> ScenarioRecord {
-        ScenarioRecord {
+    fn scenario_record() -> scenario_contract::ScenarioRecord {
+        scenario_contract::ScenarioRecord {
             scenario_id: "SCN-XK-WORKFLOW-002".to_string(),
             ac_id: Some("AC-XK-WORKFLOW-002".to_string()),
             req_id: Some("REQ-XK-WORKFLOW".to_string()),
@@ -379,23 +359,11 @@ mod tests {
             scenarios: vec![scenario_record()],
         };
 
-        assert_eq!(
-            select_matching_scenarios(&grid, "AC-XK-WORKFLOW-002").len(),
-            1
-        );
-        assert_eq!(
-            select_matching_scenarios(&grid, "SCN-XK-WORKFLOW-002").len(),
-            1
-        );
-        assert_eq!(
-            select_matching_scenarios(&grid, "@AC-XK-WORKFLOW-002").len(),
-            1
-        );
-        assert_eq!(
-            select_matching_scenarios(&grid, "@SCN-XK-WORKFLOW-002").len(),
-            1
-        );
-        assert!(select_matching_scenarios(&grid, "AC-XK-DOES-NOT-EXIST").is_empty());
+        assert_eq!(grid.select_by_selector("AC-XK-WORKFLOW-002").len(), 1);
+        assert_eq!(grid.select_by_selector("SCN-XK-WORKFLOW-002").len(), 1);
+        assert_eq!(grid.select_by_selector("@AC-XK-WORKFLOW-002").len(), 1);
+        assert_eq!(grid.select_by_selector("@SCN-XK-WORKFLOW-002").len(), 1);
+        assert!(grid.select_by_selector("AC-XK-DOES-NOT-EXIST").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Moves duplicated selector matching logic from `xtask` and `xbrlkit-bdd-steps` into the `scenario_contract` crate as inherent methods.

## Changes

- **`scenario_contract`**: Add `ScenarioRecord::matches_selector()` and `FeatureGrid::select_by_selector()`
- **`xtask`**: Remove duplicated `selector_matches()` and `select_matching_scenarios()`, update call sites + tests
- **`xbrlkit-bdd-steps`**: Remove duplicated functions, update bundle step call site

## Verification

- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all tests pass, including 8 new unit tests in `scenario_contract`)
- `cargo clippy --workspace` ✅
- `cargo xtask alpha-check` ✅

Closes #213