### PR TITLE
feat(bdd-steps): wire package check BDD step handlers for #246

### DIFF
--- a/crates/xbrlkit-bdd-steps/src/lib.rs
+++ b/crates/xbrlkit-bdd-steps/src/lib.rs
@@ -40,6 +40,7 @@ pub struct World {
     pub cli_output: Option<String>,
     pub cli_json_output: Option<serde_json::Value>,
     pub cli_exit_code: Option<i32>,
+    pub package_check_context: PackageCheckContext,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -80,6 +81,12 @@ pub struct TaxonomyLoaderContext {
     pub loaded: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct PackageCheckContext {
+    pub publishable_crates: Vec<String>,
+    pub package_results: Vec<(String, bool, String)>, // (crate_name, success, stderr)
+}
+
 impl World {
     #[must_use]
     pub fn new(repo_root: PathBuf, grid: FeatureGrid) -> Self {
@@ -102,6 +109,7 @@ impl World {
             cli_output: None,
             cli_json_output: None,
             cli_exit_code: None,
+            package_check_context: PackageCheckContext::default(),
         }
     }
 }
@@ -361,6 +369,46 @@ fn handle_given(world: &mut World, scenario: &ScenarioRecord, step: &Step) -> an
         if !has_alpha_scenarios {
             anyhow::bail!("no scenarios with @alpha-active tag found in feature files");
         }
+        return Ok(true);
+    }
+
+    // Package check Given steps
+    if step.text == "the publishable workspace crates declare crates.io-compatible manifests" {
+        let output = std::process::Command::new("cargo")
+            .args(["metadata", "--format-version", "1", "--no-deps"])
+            .current_dir(&world.repo_root)
+            .output()
+            .context("running cargo metadata for package-check")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "cargo metadata failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        let metadata: serde_json::Value =
+            serde_json::from_slice(&output.stdout).context("parsing cargo metadata output")?;
+        let packages = metadata
+            .get("packages")
+            .and_then(|p| p.as_array())
+            .context("missing packages array in cargo metadata")?;
+        let mut publishable = Vec::new();
+        for pkg in packages {
+            let name = pkg
+                .get("name")
+                .and_then(|n| n.as_str())
+                .context("missing package name")?;
+            let publish = pkg.get("publish").and_then(|p| p.as_array());
+            let is_publishable = publish.is_none_or(|registries| !registries.is_empty());
+            if is_publishable {
+                publishable.push(name.to_string());
+            }
+        }
+        publishable.sort();
+        if publishable.is_empty() {
+            anyhow::bail!("no publishable workspace crates found");
+        }
+        world.package_check_context.publishable_crates = publishable;
         return Ok(true);
     }
 
@@ -901,6 +949,35 @@ fn handle_when(world: &mut World, scenario: &ScenarioRecord, step: &Step) -> any
         return Ok(true);
     }
 
+    // Package check When steps
+    if step.text == "I run the package readiness check" {
+        let crates = world.package_check_context.publishable_crates.clone();
+        if crates.is_empty() {
+            anyhow::bail!("no publishable crates declared; Given step must run first");
+        }
+        for package in &crates {
+            let output = std::process::Command::new("cargo")
+                .args([
+                    "package",
+                    "-p",
+                    package,
+                    "--allow-dirty",
+                    "--locked",
+                    "--list",
+                ])
+                .current_dir(&world.repo_root)
+                .output()
+                .with_context(|| format!("packaging {package}"))?;
+            let success = output.status.success();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            world
+                .package_check_context
+                .package_results
+                .push((package.clone(), success, stderr));
+        }
+        return Ok(true);
+    }
+
     // Context completeness When steps
     if step.text == "context completeness validation runs" {
         // Build ContextSet from contexts
@@ -1211,6 +1288,25 @@ fn handle_then(world: &mut World, step: &Step) -> anyhow::Result<()> {
                 anyhow::bail!(
                     "alpha readiness gate failed with exit code {exit_code}\noutput:\n{output}"
                 );
+            }
+            Ok(())
+        }
+        "the publishable workspace crates package successfully" => {
+            let results = &world.package_check_context.package_results;
+            if results.is_empty() {
+                anyhow::bail!("package readiness check was not executed");
+            }
+            let failures: Vec<_> = results
+                .iter()
+                .filter(|(_, success, _)| !success)
+                .collect();
+            if !failures.is_empty() {
+                use std::fmt::Write;
+                let mut msg = String::from("package check failed for:\n");
+                for (name, _, stderr) in &failures {
+                    let _ = write!(msg, "  - {name}\n{stderr}\n");
+                }
+                anyhow::bail!(msg);
             }
             Ok(())
         }

--- a/specs/features/workflow/package_check.feature
+++ b/specs/features/workflow/package_check.feature
@@ -6,6 +6,7 @@ Feature: Package check
   @AC-XK-WORKFLOW-004
   @SCN-XK-WORKFLOW-006
   @speed.fast
+  @alpha-active
   Scenario: Verify publishable crates package for crates.io
     Given the publishable workspace crates declare crates.io-compatible manifests
     When I run the package readiness check

--- a/specs/features/workflow/package_check.meta.yaml
+++ b/specs/features/workflow/package_check.meta.yaml
@@ -5,7 +5,7 @@ scenarios:
   SCN-XK-WORKFLOW-006:
     ac_id: AC-XK-WORKFLOW-004
     req_id: REQ-XK-WORKFLOW
-    crates: [xtask, xbrlkit-core]
+    crates: [xbrlkit-core, xbrlkit-conform, taxonomy-types, taxonomy-package, taxonomy-dts, taxonomy-loader, xbrl-report-types, xbrl-contexts, xbrl-units, xbrl-dimensions, xbrl-linkbases, xbrl-stream, validation-run, filing-load, efm-rules, sec-http, sec-profile-types, edgar-identity, edgar-sgml, edgar-attachments, receipt-types, render-json, render-md, corpus-fs, cockpit-export, oim-normalize, export-run, diff-run, oracle-compare, calc11, duplicate-facts, context-completeness, dimensional-rules, numeric-rules, unit-rules, ixhtml-scan, ixds-assemble, archive-zip]
     fixtures: []
     receipts: [scenario.run.v1]
     suite: synthetic


### PR DESCRIPTION
## Summary

Implements the 3 BDD step handlers for the package check scenario (SCN-XK-WORKFLOW-006 / AC-XK-WORKFLOW-004).

### Changes Made

- **crates/xbrlkit-bdd-steps/src/lib.rs**
  - Add PackageCheckContext to World state
  - Add Given handler: parses workspace via cargo metadata, filters publishable crates
  - Add When handler: runs cargo package --allow-dirty --locked --list for each publishable crate
  - Add Then handler: asserts all packages succeeded
- **specs/features/workflow/package_check.feature**
  - Add @alpha-active tag to enable the scenario in the alpha gate

### Plan Reference

.mend/plans/ISSUE-246.md

### Local Validation

Cargo was not available in the build environment, so local validation (cargo check -p xbrlkit-bdd-steps) could not be run. The code follows the exact patterns used by existing step handlers in lib.rs and by the existing xtask package_check() implementation.

Closes #246