### PR TITLE
fix(deps): remove unused async-tokio feature from quick-xml in xbrl-stream (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `cargo xtask package-check` and CI coverage to keep publishable crates packaging cleanly for crates.io.
 - Switched internal workspace dependencies to inherited workspace entries so packaged manifests carry registry-compatible versions.
 - Marked workspace-only tooling crates, scenario crates, and the workspace-bound CLI as `publish = false`.
+- Removed unused `async-tokio` feature from `quick-xml` dependency in `xbrl-stream`, along with the unused `tokio` dev-dependency.
 
 ## 0.1.0-alpha.1 - 2026-03-17
 

--- a/crates/xbrl-stream/Cargo.toml
+++ b/crates/xbrl-stream/Cargo.toml
@@ -10,13 +10,10 @@ description = "SAX-style streaming XBRL parser for large filings"
 path = "src/lib.rs"
 
 [dependencies]
-quick-xml = { version = "0.36", features = ["async-tokio"] }
+quick-xml = { version = "0.36" }
 thiserror = "1.0"
 anyhow = "1.0"
 xbrl-report-types.workspace = true
-
-[dev-dependencies]
-tokio.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
fix(deps): remove unused async-tokio feature from quick-xml in xbrl-stream (#289)

Removes the unused `async-tokio` feature from the `quick-xml` dependency in
`crates/xbrl-stream/Cargo.toml`. The crate has no async I/O paths and only
uses `quick-xml`'s synchronous `Reader`.

Also removes the unused `tokio` dev-dependency discovered during deep review.

CHANGELOG:
- Add entry under ## Unreleased

Closes #289
