### PR TITLE
fix(xbrl-stream): remove unused quick-xml async-tokio feature (#289)

### DIFF
--- a/crates/xbrl-stream/Cargo.toml
+++ b/crates/xbrl-stream/Cargo.toml
@@ -10,13 +10,10 @@ description = "SAX-style streaming XBRL parser for large filings"
 path = "src/lib.rs"
 
 [dependencies]
-quick-xml = { version = "0.36", features = ["async-tokio"] }
+quick-xml = { version = "0.36" }
 thiserror = "1.0"
 anyhow = "1.0"
 xbrl-report-types.workspace = true
-
-[dev-dependencies]
-tokio.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Removes the unused "async-tokio" feature flag from the  dependency in . The crate only uses the synchronous  API, so the feature pulled in , , and related runtime dependencies with no benefit.

Also removes the unused  dev-dependency, which had zero usage in the crate (no async code anywhere in ).

## Changes

- 
  - Removed  from  features
  - Removed unused 

## Verification

| Check | Result |
|-------|--------|
|  | PASS |
|  | PASS (all unit + doc tests) |
|  | PASS |
|  |  eliminated from normal deps |

## Plan Reference

Implementation follows the approved plan: 

## Risk Assessment

Low. Single-file Cargo.toml edit with zero source code changes. No public API changes. The quick-xml version stays the same; only feature flags change.

Closes #289