### PR TITLE
ci(codecov): add advisory coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,125 @@
+name: Coverage
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "xtask/**"
+      - "specs/**"
+      - "contracts/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+      - "docs/ci/coverage.md"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "xtask/**"
+      - "specs/**"
+      - "contracts/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+      - "docs/ci/coverage.md"
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+jobs:
+  coverage:
+    name: Codecov Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.92.0"
+          components: llvm-tools-preview
+      - name: Use larger target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-directories: ${{ runner.temp }}/target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install coverage tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+      - name: Generate coverage
+        env:
+          CI: true
+          PROPTEST_CASES: "100"
+          INSTA_UPDATE: "no"
+        run: |
+          set -euo pipefail
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov nextest \
+            --workspace \
+            --locked \
+            --no-report
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
+      - name: Validate coverage output
+        run: |
+          set -euo pipefail
+          test -s coverage.json
+          test -s coverage.txt
+          test -s lcov.info
+      - name: Detect Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "${CODECOV_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload coverage to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-alpha
+          name: xbrlkit-rust-alpha
+          fail_ci_if_error: true
+      - name: Upload coverage to Codecov (advisory)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-alpha
+          name: xbrlkit-rust-alpha
+          fail_ci_if_error: false
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.txt
+            lcov.info
+          retention-days: 14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -113,6 +113,58 @@ jobs:
           flags: rust-alpha
           name: xbrlkit-rust-alpha
           fail_ci_if_error: false
+      - name: Write coverage receipt
+        if: always()
+        run: |
+          mkdir -p target/coverage
+          python3 - <<'PY'
+          import json
+          import pathlib
+          receipt = {
+              "schema_version": 1,
+              "repo": "xbrlkit",
+              "lane": "coverage",
+              "tool": "cargo-llvm-cov",
+              "flag": "rust-alpha",
+              "workflow": "Coverage",
+              "artifacts": {
+                  "coverage_json": pathlib.Path("coverage.json").exists(),
+                  "coverage_text": pathlib.Path("coverage.txt").exists(),
+                  "lcov": pathlib.Path("lcov.info").exists(),
+              },
+              "claim_boundary": [
+                  "execution_surface_only",
+                  "not_xbrl_correctness",
+                  "not_sec_efm_completeness",
+                  "not_edgar_readiness",
+                  "not_taxonomy_correctness",
+                  "not_inline_xbrl_completeness",
+                  "not_oracle_parity",
+                  "not_bdd_completeness",
+                  "not_release_readiness"
+              ],
+          }
+          pathlib.Path("target/coverage/coverage-receipt.json").write_text(
+              json.dumps(receipt, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: Summarize coverage artifacts
+        if: always()
+        run: |
+          {
+            echo "## Coverage"
+            echo ""
+            echo "| Artifact | Present |"
+            echo "| --- | ---: |"
+            echo "| coverage.json | $([ -s coverage.json ] && echo yes || echo no) |"
+            echo "| coverage.txt | $([ -s coverage.txt ] && echo yes || echo no) |"
+            echo "| lcov.info | $([ -s lcov.info ] && echo yes || echo no) |"
+            echo "| coverage-receipt.json | $([ -s target/coverage/coverage-receipt.json ] && echo yes || echo no) |"
+            echo ""
+            echo "Codecov flag: \`rust-alpha\`"
+            echo "Claim boundary: execution-surface evidence only."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -122,4 +174,5 @@ jobs:
             coverage.json
             coverage.txt
             lcov.info
+            target/coverage/coverage-receipt.json
           retention-days: 14

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # xbrlkit
 
+[![CI](https://github.com/EffortlessMetrics/xbrlkit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/EffortlessMetrics/xbrlkit/actions/workflows/ci.yml)
+[![Coverage](https://github.com/EffortlessMetrics/xbrlkit/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/EffortlessMetrics/xbrlkit/actions/workflows/coverage.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/xbrlkit/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/xbrlkit)
+[![MSRV](https://img.shields.io/badge/MSRV-1.92-blue.svg)](Cargo.toml)
+[![License](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
+
 Alpha Rust workspace for XBRL / iXBRL + EDGAR processing, aimed first at SEC operating-company filings.
+
+Codecov is execution-surface telemetry only; see [Coverage](docs/ci/coverage.md) for what the badge does and does not claim.
 
 ## What this workspace is for
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-alpha
+    patch:
+      default:
+        target: 70%
+        threshold: 20%
+        informational: true
+        flags:
+          - rust-alpha
+comment: false
+github_checks:
+  annotations: false
+ignore:
+  - "target/**"
+  - "fixtures/**"
+  - "corpus/**"
+  - "profiles/**"
+  - "contracts/**"
+  - "specs/**"
+  - "crates/*/benches/**"
+  - "crates/*/examples/**"

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,37 @@
+# Coverage
+
+Codecov coverage is Rust execution-surface evidence.
+
+It answers:
+> Did tests execute this Rust surface?
+
+It does not answer:
+- whether XBRL validation is correct,
+- whether SEC EFM coverage is complete,
+- whether EDGAR filing handling is complete,
+- whether taxonomy loading is correct for broad real-world filings,
+- whether inline XBRL document sets are complete,
+- whether oracle comparison is complete,
+- whether BDD coverage is complete,
+- whether package readiness is proven,
+- whether release readiness is proven.
+
+Those are separate proof lanes.
+
+## Workflow
+
+The Coverage workflow runs on:
+- push to `main`,
+- `workflow_dispatch`,
+- PRs labeled `coverage`, `full-ci`, or `ci:full`.
+
+The initial Codecov flag is `rust-alpha`, scoped to Rust execution coverage for the alpha workspace.
+
+## Receipts
+
+Codecov comments are disabled. Durable receipts are:
+- `coverage.json`,
+- `coverage.txt`,
+- `lcov.info`,
+- the GitHub Actions coverage artifact,
+- the Codecov dashboard.

--- a/tests/goldens/feature.grid.v1.json
+++ b/tests/goldens/feature.grid.v1.json
@@ -335,7 +335,7 @@
     {
       "scenario_id": "SCN-XK-EXPORT-001",
       "ac_id": "AC-XK-EXPORT-001",
-      "req_id": null,
+      "req_id": "REQ-XK-EXPORT",
       "feature_file": "specs/features/export/oim_json.feature",
       "sidecar_file": "specs/features/export/oim_json.meta.yaml",
       "layer": "workflow",
@@ -1595,7 +1595,7 @@
     {
       "scenario_id": "SCN-XK-WORKFLOW-003",
       "ac_id": null,
-      "req_id": null,
+      "req_id": "REQ-XK-WORKFLOW",
       "feature_file": "specs/features/workflow/cockpit_pack.feature",
       "sidecar_file": "specs/features/workflow/cockpit_pack.meta.yaml",
       "layer": "workflow",


### PR DESCRIPTION
## Summary
Implements the complete Codecov integration for xbrlkit following the SRP rollout plan. This PR bundles logical steps PR 1-5 into focused commits:

1. **PR 1**: `.github/workflows/coverage.yml` – Advisory coverage workflow
2. **PR 2**: `codecov.yml` – Quiet Codecov config  
3. **PR 3**: README badges – CI, Coverage, Codecov, MSRV, License
4. **PR 4**: `docs/ci/coverage.md` – Coverage claim boundaries
5. **PR 5**: Coverage receipt artifact – JSON receipt + step summary

Also includes a pre-requisite fix: Golden file update for spec-ledger REQ additions (issue #243).

## Changes
- `.github/workflows/coverage.yml`: New workflow for cargo-llvm-cov coverage analysis
  - Runs on main, workflow_dispatch, and PRs labeled `coverage`, `full-ci`, `ci:full`
  - Advisory (non-blocking) Codecov uploads on PRs; blocking on main only
  - Generates coverage.json, coverage.txt, lcov.info artifacts
  - Requires optional CODECOV_TOKEN secret
- `codecov.yml`: Advisory status configuration
  - Project/patch targets with informational thresholds
  - Comments disabled, annotations disabled
  - Ignored: target/, fixtures/, corpus/, profiles/, contracts/, specs/, benches/, examples/
- `README.md`: Badge block added (CI, Coverage, Codecov, MSRV, License)
  - Claim boundary note linking to coverage documentation
- `docs/ci/coverage.md`: Coverage lane documentation
  - Documents what Codecov answers (Rust execution-surface) and does NOT answer
  - Receipts: coverage.json, coverage.txt, lcov.info, artifacts, dashboard
- Coverage receipt artifact:
  - Generates `target/coverage/coverage-receipt.json` with claim boundaries
  - Step summary table showing artifact presence
- `tests/goldens/feature.grid.v1.json`: Updated after spec-ledger REQ additions

## CI economics
- Workflow touched: `.github/workflows/coverage.yml` (new, no changes to `ci.yml`)
- Runtime: ~45min on ubuntu-latest (deferred to optional coverage lane)
- Codecov: Fail-blocking on main only; advisory (non-blocking) on PRs
- Coverage artifacts: Generated on every run, retained 14 days
- Token: Requires optional `CODECOV_TOKEN` secret (workflow generates local artifacts without it)
- Branch protection: No changes; Codecov remains advisory
- Rollback: Revert all files added and the README modification

## Claim boundary
Codecov coverage is Rust execution-surface evidence only. It does **not** prove:
- XBRL correctness
- SEC EFM completeness
- EDGAR readiness
- Taxonomy correctness
- Inline XBRL completeness
- Oracle parity
- BDD completeness
- Package readiness
- Release readiness

Those are separate proof lanes.

## Validation
- [x] `git diff --check`
- [x] YAML syntax validation (coverage.yml, codecov.yml)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo xtask alpha-check`
- [x] Golden file updated for spec-ledger REQ additions

## Notes
- No changes to existing `ci.yml` alpha gate
- Coverage workflow runs in parallel to ci.yml, not in series
- Receipts are durable and schema'd (coverage-receipt.json)
- Ready for Codecov token setup and workflow runs