### PR TITLE
fix(numeric-rules): correct decimals adjustment for scientific notation

### DIFF
--- a/crates/numeric-rules/src/decimal_precision.rs
+++ b/crates/numeric-rules/src/decimal_precision.rs
@@ -93,12 +93,15 @@ fn would_truncate_nonzero_digits(value: &str, decimals: i32) -> bool {
     // Remove any whitespace
     let value = value.trim();
 
-    // Handle scientific notation
+    // Handle scientific notation: m * 10^e is rounded to 10^(-decimals).
+    // Rounding the mantissa to 10^(-decimals') yields the same result when
+    // decimals' = decimals + e (so 1.5e-2 with decimals=2 maps to 1.5 with decimals'=0).
     if let Some(exp_pos) = value.to_lowercase().find('e') {
         let (mantissa, exp) = value.split_at(exp_pos);
-        let exp_val: i32 = exp[1..].parse().unwrap_or(0);
-        // Adjust decimals for scientific notation
-        return would_truncate_nonzero_digits(mantissa, decimals - exp_val);
+        if let Ok(exp_val) = exp[1..].parse::<i32>() {
+            return would_truncate_nonzero_digits(mantissa, decimals + exp_val);
+        }
+        return false;
     }
 
     // Parse the numeric value
@@ -266,6 +269,39 @@ mod tests {
     fn valid_thousands_rounding() {
         // 1234000 with decimals="-3" is valid (rounds to thousands, 1234 is preserved)
         let facts = vec![fact_with_decimals("us-gaap:Revenue", "1234000", "-3")];
+        let findings = validate_decimal_precision(&facts);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn invalid_truncation_with_negative_exponent() {
+        // 1.5e-2 = 0.015. decimals="2" rounds to 0.02 — truncates the '5'.
+        let facts = vec![fact_with_decimals("us-gaap:Revenue", "1.5e-2", "2")];
+        let findings = validate_decimal_precision(&facts);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "fs-0637-Nonzero-Digits-Truncated");
+    }
+
+    #[test]
+    fn invalid_truncation_with_positive_exponent() {
+        // 1.5e3 = 1500. decimals="-3" rounds to thousands — truncates the '5' in hundreds place.
+        let facts = vec![fact_with_decimals("us-gaap:Revenue", "1.5e3", "-3")];
+        let findings = validate_decimal_precision(&facts);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn valid_scientific_notation_no_truncation() {
+        // 1.5e-2 = 0.015. decimals="3" keeps all significant digits.
+        let facts = vec![fact_with_decimals("us-gaap:Revenue", "1.5e-2", "3")];
+        let findings = validate_decimal_precision(&facts);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn valid_scientific_notation_uppercase_e() {
+        // 1.0E3 = 1000. decimals="-3" exactly rounds to thousands, no truncation.
+        let facts = vec![fact_with_decimals("us-gaap:Revenue", "1.0E3", "-3")];
         let findings = validate_decimal_precision(&facts);
         assert!(findings.is_empty());
     }


### PR DESCRIPTION
## Summary

Fixes a sign error in `numeric-rules`' EFM 6.5.37 (Nonzero Digits Truncated) check that silently passed any fact written in scientific notation.

In `would_truncate_nonzero_digits` (`crates/numeric-rules/src/decimal_precision.rs`), the scientific-notation branch recursed with `decimals - exp_val` when it should have used `decimals + exp_val`.

For a fact `m * 10^e` checked against `10^(-decimals)`, rounding the mantissa to `10^(-decimals')` produces the same result only when `decimals' = decimals + e`. Example:

- `1.5e-2` (= 0.015) with `decimals="2"` rounds to `0.02`, truncating the `5` → should be a violation.
- Before: recursed with `("1.5", 2 - (-2)) = ("1.5", 4)` → 1 significant fractional digit ≤ 4 → no violation reported (wrong).
- After: recurses with `("1.5", 2 + (-2)) = ("1.5", 0)` → 1 > 0 → violation reported (correct).

Also tightened the exponent parse: a malformed exponent now bails out instead of falling through with `exp_val = 0`.

## Test plan

- [x] `cargo test -p numeric-rules` — 24/24 pass
- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy -p numeric-rules --all-targets` — clean
- [x] Added 4 regression tests:
  - `invalid_truncation_with_negative_exponent` — `1.5e-2` with `decimals="2"`
  - `invalid_truncation_with_positive_exponent` — `1.5e3` with `decimals="-3"`
  - `valid_scientific_notation_no_truncation` — `1.5e-2` with `decimals="3"`
  - `valid_scientific_notation_uppercase_e` — `1.0E3` with `decimals="-3"`

https://claude.ai/code/session_01C2AEhfMPp8Yhapns34xrbB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2AEhfMPp8Yhapns34xrbB)_