### PR TITLE
chore(deps): remove unused render-md dependency from xbrlkit-cli

### DIFF
--- a/crates/xbrlkit-cli/Cargo.toml
+++ b/crates/xbrlkit-cli/Cargo.toml
@@ -21,7 +21,6 @@ sec-profile-types.workspace = true
 validation-run.workspace = true
 export-run.workspace = true
 render-json.workspace = true
-render-md.workspace = true
 xbrl-report-types.workspace = true
 xbrl-contexts.workspace = true
 taxonomy-loader.workspace = true


### PR DESCRIPTION
Removes the unused `render-md` workspace dependency from `crates/xbrlkit-cli/Cargo.toml`.

**Context:**
- Issue: #304
- Plan: `.mend/plans/ISSUE-304.md`

**Verification:**
- `cargo check -p xbrlkit-cli` passes
- `cargo test -p xbrlkit-cli` passes
- Zero references to `render-md` or `render_md` remain in `crates/xbrlkit-cli/src/`

The dependency remains available in the workspace for other crates that may need it.