### PR TITLE
fix(dimensional-rules): replace unwrap on taxonomy lookup with ok_or_else + ? propagation

### DIFF
--- a/crates/dimensional-rules/src/lib.rs
+++ b/crates/dimensional-rules/src/lib.rs
@@ -145,19 +145,14 @@ fn validate_dimension_member(
     dim_member: &DimensionMember,
     dim_taxonomy: &DimensionTaxonomy,
 ) -> Result<(), ValidationFinding> {
-    // Check if dimension exists
-    if !dim_taxonomy.dimensions.contains_key(&dim_member.dimension) {
-        return Err(ValidationFinding {
-            rule_id: "XBRL.DIMENSION.UNKNOWN".to_string(),
-            severity: "error".to_string(),
-            message: format!("Unknown dimension: {}", dim_member.dimension),
-            member: Some(dim_member.dimension.clone()),
-            subject: Some(dim_member.member.clone()),
-        });
-    }
-
-    // Get the dimension definition
-    let dimension = dim_taxonomy.dimensions.get(&dim_member.dimension).unwrap();
+    // Get the dimension definition, or return an error if it doesn't exist
+    let dimension = dim_taxonomy.dimensions.get(&dim_member.dimension).ok_or_else(|| ValidationFinding {
+        rule_id: "XBRL.DIMENSION.UNKNOWN".to_string(),
+        severity: "error".to_string(),
+        message: format!("Unknown dimension: {}", dim_member.dimension),
+        member: Some(dim_member.dimension.clone()),
+        subject: Some(dim_member.member.clone()),
+    })?;
 
     // If it's a typed dimension, validate the value against the expected type
     if dimension.is_typed() {


### PR DESCRIPTION
## Summary

Replaces the production `unwrap()` at `crates/dimensional-rules/src/lib.rs:160` with a single lookup using `.ok_or_else()` + `?` propagation.

### Changes
- Consolidates the `contains_key` guard and `get().unwrap()` into one operation
- Returns a `ValidationFinding` with `rule_id: XBRL.DIMENSION.UNKNOWN` if the dimension is missing from the taxonomy
- No new DTOs, no schema changes

### Validation
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all 17 dimensional-rules tests pass)
- `cargo clippy --workspace` ✅ clean

Closes #332