### PR TITLE
feat(validation): add ValidationFinding constructor helpers (Phase 1)

### DIFF
--- a/crates/context-completeness/src/lib.rs
+++ b/crates/context-completeness/src/lib.rs
@@ -29,13 +29,12 @@ pub fn validate_context_completeness(
 
         // Check if context exists (case-insensitive lookup)
         if contexts.get(context_ref).is_none() {
-            findings.push(ValidationFinding {
-                rule_id: "SEC-CONTEXT-001".to_string(),
-                severity: "error".to_string(),
-                message: format!("Fact references undefined context: '{}'", context_ref),
-                member: Some(fact.member.clone()),
-                subject: Some(fact.concept.clone()),
-            });
+            findings.push(ValidationFinding::for_fact(
+                "SEC-CONTEXT-001",
+                "error",
+                fact,
+                format!("Fact references undefined context: '{}'", context_ref),
+            ));
         }
     }
 

--- a/crates/dimensional-rules/src/lib.rs
+++ b/crates/dimensional-rules/src/lib.rs
@@ -58,16 +58,16 @@ pub fn validate_fact_dimensions(
         let Some(context) = context_set.get(&fact.context_ref) else {
             results.push(DimensionalValidationResult {
                 context_id: fact.context_ref.clone(),
-                findings: vec![ValidationFinding {
-                    rule_id: "XBRL.DIMENSION.MISSING_CONTEXT".to_string(),
-                    severity: "error".to_string(),
-                    message: format!(
+                findings: vec![ValidationFinding::new(
+                    "XBRL.DIMENSION.MISSING_CONTEXT",
+                    "error",
+                    format!(
                         "Context {} not found for fact {}",
                         fact.context_ref, fact.concept
                     ),
-                    member: Some(fact.concept.clone()),
-                    subject: Some(fact.context_ref.clone()),
-                }],
+                )
+                .with_member(&fact.concept)
+                .with_subject(&fact.context_ref)],
                 present_dimensions: Vec::new(),
                 missing_dimensions: Vec::new(),
             });
@@ -112,16 +112,16 @@ pub fn validate_context_dimensions(
     for req_dim in &required_dims {
         if !present_dimensions.contains(req_dim) {
             missing_dimensions.push(req_dim.clone());
-            findings.push(ValidationFinding {
-                rule_id: "XBRL.DIMENSION.MISSING_REQUIRED".to_string(),
-                severity: "error".to_string(),
-                message: format!(
+            findings.push(ValidationFinding::new(
+                "XBRL.DIMENSION.MISSING_REQUIRED",
+                "error",
+                format!(
                     "Concept {} requires dimension {} which is missing in context {}",
                     concept_qname, req_dim, context.id
                 ),
-                member: Some(concept_qname.to_string()),
-                subject: Some(context.id.clone()),
-            });
+            )
+            .with_member(concept_qname)
+            .with_subject(&context.id));
         }
     }
 
@@ -147,13 +147,13 @@ fn validate_dimension_member(
 ) -> Result<(), ValidationFinding> {
     // Check if dimension exists
     if !dim_taxonomy.dimensions.contains_key(&dim_member.dimension) {
-        return Err(ValidationFinding {
-            rule_id: "XBRL.DIMENSION.UNKNOWN".to_string(),
-            severity: "error".to_string(),
-            message: format!("Unknown dimension: {}", dim_member.dimension),
-            member: Some(dim_member.dimension.clone()),
-            subject: Some(dim_member.member.clone()),
-        });
+        return Err(ValidationFinding::for_dimension_member(
+            "XBRL.DIMENSION.UNKNOWN",
+            "error",
+            &dim_member.dimension,
+            &dim_member.member,
+            format!("Unknown dimension: {}", dim_member.dimension),
+        ));
     }
 
     // Get the dimension definition
@@ -171,26 +171,26 @@ fn validate_dimension_member(
         if domain.contains(&dim_member.member) {
             return Ok(());
         }
-        return Err(ValidationFinding {
-            rule_id: "XBRL.DIMENSION.INVALID_MEMBER".to_string(),
-            severity: "error".to_string(),
-            message: format!(
+        return Err(ValidationFinding::new(
+            "XBRL.DIMENSION.INVALID_MEMBER",
+            "error",
+            format!(
                 "Member {} is not valid for dimension {} in domain {}",
                 dim_member.member, dim_member.dimension, domain_qname
             ),
-            member: Some(dim_member.member.clone()),
-            subject: Some(dim_member.dimension.clone()),
-        });
+        )
+        .with_member(&dim_member.member)
+        .with_subject(&dim_member.dimension));
     }
 
     // No domain defined for this dimension
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.NO_DOMAIN".to_string(),
-        severity: "error".to_string(),
-        message: format!("Dimension {} has no domain defined", dim_member.dimension),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(dim_member.member.clone()),
-    })
+    Err(ValidationFinding::for_dimension_member(
+        "XBRL.DIMENSION.NO_DOMAIN",
+        "error",
+        &dim_member.dimension,
+        &dim_member.member,
+        format!("Dimension {} has no domain defined", dim_member.dimension),
+    ))
 }
 
 /// Validate a typed dimension value against its declared `value_type`.
@@ -211,13 +211,13 @@ fn validate_typed_dimension_value(
 
     // Check for empty value
     if value.trim().is_empty() {
-        return Err(ValidationFinding {
-            rule_id: "XBRL.DIMENSION.EMPTY_TYPED_VALUE".to_string(),
-            severity: "error".to_string(),
-            message: format!("Typed dimension {} has empty value", dim_member.dimension),
-            member: Some(dim_member.dimension.clone()),
-            subject: Some(value.to_string()),
-        });
+        return Err(ValidationFinding::new(
+            "XBRL.DIMENSION.EMPTY_TYPED_VALUE",
+            "error",
+            format!("Typed dimension {} has empty value", dim_member.dimension),
+        )
+        .with_member(&dim_member.dimension)
+        .with_subject(value));
     }
 
     // Validate based on value_type
@@ -258,16 +258,16 @@ fn validate_decimal(value: &str, dim_member: &DimensionMember) -> Result<(), Val
         }
     }
 
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
-        severity: "error".to_string(),
-        message: format!(
+    Err(ValidationFinding::new(
+        "XBRL.DIMENSION.INVALID_TYPED_VALUE",
+        "error",
+        format!(
             "Value '{}' is not a valid decimal for dimension {}",
             value, dim_member.dimension
         ),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(value.to_string()),
-    })
+    )
+    .with_member(&dim_member.dimension)
+    .with_subject(value))
 }
 
 /// Validate integer format.
@@ -285,16 +285,16 @@ fn validate_integer(value: &str, dim_member: &DimensionMember) -> Result<(), Val
         return Ok(());
     }
 
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
-        severity: "error".to_string(),
-        message: format!(
+    Err(ValidationFinding::new(
+        "XBRL.DIMENSION.INVALID_TYPED_VALUE",
+        "error",
+        format!(
             "Value '{}' is not a valid integer for dimension {}",
             value, dim_member.dimension
         ),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(value.to_string()),
-    })
+    )
+    .with_member(&dim_member.dimension)
+    .with_subject(value))
 }
 
 /// Validate date format (ISO 8601: YYYY-MM-DD).
@@ -328,16 +328,16 @@ fn validate_date(value: &str, dim_member: &DimensionMember) -> Result<(), Valida
         }
     }
 
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
-        severity: "error".to_string(),
-        message: format!(
+    Err(ValidationFinding::new(
+        "XBRL.DIMENSION.INVALID_TYPED_VALUE",
+        "error",
+        format!(
             "Value '{}' is not a valid date (expected YYYY-MM-DD) for dimension {}",
             value, dim_member.dimension
         ),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(value.to_string()),
-    })
+    )
+    .with_member(&dim_member.dimension)
+    .with_subject(value))
 }
 
 /// Validate datetime format (ISO 8601).
@@ -360,16 +360,16 @@ fn validate_datetime(value: &str, dim_member: &DimensionMember) -> Result<(), Va
         }
     }
 
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
-        severity: "error".to_string(),
-        message: format!(
+    Err(ValidationFinding::new(
+        "XBRL.DIMENSION.INVALID_TYPED_VALUE",
+        "error",
+        format!(
             "Value '{}' is not a valid dateTime for dimension {}",
             value, dim_member.dimension
         ),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(value.to_string()),
-    })
+    )
+    .with_member(&dim_member.dimension)
+    .with_subject(value))
 }
 
 /// Validate boolean format.
@@ -380,16 +380,16 @@ fn validate_boolean(value: &str, dim_member: &DimensionMember) -> Result<(), Val
         return Ok(());
     }
 
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
-        severity: "error".to_string(),
-        message: format!(
+    Err(ValidationFinding::new(
+        "XBRL.DIMENSION.INVALID_TYPED_VALUE",
+        "error",
+        format!(
             "Value '{}' is not a valid boolean (expected true/false/1/0) for dimension {}",
             value, dim_member.dimension
         ),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(value.to_string()),
-    })
+    )
+    .with_member(&dim_member.dimension)
+    .with_subject(value))
 }
 
 /// Validate URI format.
@@ -402,16 +402,16 @@ fn validate_uri(value: &str, dim_member: &DimensionMember) -> Result<(), Validat
         return Ok(());
     }
 
-    Err(ValidationFinding {
-        rule_id: "XBRL.DIMENSION.INVALID_TYPED_VALUE".to_string(),
-        severity: "error".to_string(),
-        message: format!(
+    Err(ValidationFinding::new(
+        "XBRL.DIMENSION.INVALID_TYPED_VALUE",
+        "error",
+        format!(
             "Value '{}' is not a valid URI for dimension {}",
             value, dim_member.dimension
         ),
-        member: Some(dim_member.dimension.clone()),
-        subject: Some(value.to_string()),
-    })
+    )
+    .with_member(&dim_member.dimension)
+    .with_subject(value))
 }
 
 /// Check if a member is a descendant of another member in a domain.

--- a/crates/numeric-rules/src/decimal_precision.rs
+++ b/crates/numeric-rules/src/decimal_precision.rs
@@ -48,16 +48,15 @@ fn check_decimal_truncation(fact: &Fact, decimals: &str) -> Option<ValidationFin
 
     // Check for truncation based on decimals value
     if would_truncate_nonzero_digits(value, decimals_val) {
-        return Some(ValidationFinding {
-            rule_id: "fs-0637-Nonzero-Digits-Truncated".to_string(),
-            severity: "error".to_string(),
-            message: format!(
+        return Some(ValidationFinding::for_fact(
+            "fs-0637-Nonzero-Digits-Truncated",
+            "error",
+            fact,
+            format!(
                 "Value '{}' has decimals='{}' which truncates non-zero digits (EFM 6.5.37)",
                 fact.value, decimals
             ),
-            member: Some(fact.member.clone()),
-            subject: Some(fact.concept.clone()),
-        });
+        ));
     }
 
     None

--- a/crates/numeric-rules/src/lib.rs
+++ b/crates/numeric-rules/src/lib.rs
@@ -35,16 +35,15 @@ pub fn validate_negative_values(
             && is_negative
             && concept_prohibits_negative(&fact.concept, prohibited_concepts)
         {
-            findings.push(ValidationFinding {
-                rule_id: format!("SEC.NEGATIVE_VALUE.{}", sanitize_for_rule_id(&fact.concept)),
-                severity: "error".to_string(),
-                message: format!(
+            findings.push(ValidationFinding::for_fact(
+                format!("SEC.NEGATIVE_VALUE.{}", sanitize_for_rule_id(&fact.concept)),
+                "error",
+                fact,
+                format!(
                     "Concept '{}' has negative value '{}' but does not allow negative values",
                     fact.concept, fact.value
                 ),
-                member: Some(fact.member.clone()),
-                subject: Some(fact.concept.clone()),
-            });
+            ));
         }
     }
 

--- a/crates/unit-rules/src/validator.rs
+++ b/crates/unit-rules/src/validator.rs
@@ -72,16 +72,15 @@ impl UnitValidator {
         if valid {
             None
         } else {
-            Some(ValidationFinding {
-                rule_id: "SEC-UNIT-001".to_string(),
-                severity: "error".to_string(),
-                message: format!(
+            Some(ValidationFinding::for_fact(
+                "SEC-UNIT-001",
+                "error",
+                fact,
+                format!(
                     "Unit inconsistency: concept '{}' expects {:?} unit but found '{}'",
                     fact.concept, expected, unit_measure
                 ),
-                member: Some(fact.member.clone()),
-                subject: Some(fact.concept.clone()),
-            })
+            ))
         }
     }
 

--- a/crates/validation-run/src/lib.rs
+++ b/crates/validation-run/src/lib.rs
@@ -110,22 +110,18 @@ fn apply_duplicate_fact_findings(report: &mut CanonicalReport) {
     match classify(report) {
         DuplicateDisposition::None => {}
         DuplicateDisposition::Consistent => {
-            report.findings.push(ValidationFinding {
-                rule_id: "XBRL.DUPLICATE_FACT.CONSISTENT".to_string(),
-                severity: "info".to_string(),
-                message: "Consistent duplicate facts detected".to_string(),
-                member: None,
-                subject: None,
-            });
+            report.findings.push(ValidationFinding::new(
+                "XBRL.DUPLICATE_FACT.CONSISTENT",
+                "info",
+                "Consistent duplicate facts detected",
+            ));
         }
         DuplicateDisposition::Inconsistent => {
-            report.findings.push(ValidationFinding {
-                rule_id: "XBRL.DUPLICATE_FACT.INCONSISTENT".to_string(),
-                severity: "error".to_string(),
-                message: "Inconsistent duplicate facts detected".to_string(),
-                member: None,
-                subject: None,
-            });
+            report.findings.push(ValidationFinding::new(
+                "XBRL.DUPLICATE_FACT.INCONSISTENT",
+                "error",
+                "Inconsistent duplicate facts detected",
+            ));
         }
     }
 }
@@ -161,25 +157,23 @@ pub fn validate_contexts(xbrl_xml: &str) -> Result<(ContextSet, Vec<ValidationFi
     // Check for contexts without entity identifiers
     for context in context_set.iter() {
         if context.entity.value.is_empty() {
-            findings.push(ValidationFinding {
-                rule_id: "XBRL.CONTEXT.MISSING_ENTITY".to_string(),
-                severity: "error".to_string(),
-                message: format!("Context {} has no entity identifier", context.id),
-                member: None,
-                subject: Some(context.id.clone()),
-            });
+            findings.push(ValidationFinding::for_context(
+                "XBRL.CONTEXT.MISSING_ENTITY",
+                "error",
+                &context.id,
+                format!("Context {} has no entity identifier", context.id),
+            ));
         }
 
         // Check for contexts with dimensional information
         let dim_count = xbrl_contexts::get_dimensional_members(context).len();
         if dim_count > 0 {
-            findings.push(ValidationFinding {
-                rule_id: "XBRL.CONTEXT.HAS_DIMENSIONS".to_string(),
-                severity: "info".to_string(),
-                message: format!("Context {} has {dim_count} dimensional members", context.id),
-                member: None,
-                subject: Some(context.id.clone()),
-            });
+            findings.push(ValidationFinding::for_context(
+                "XBRL.CONTEXT.HAS_DIMENSIONS",
+                "info",
+                &context.id,
+                format!("Context {} has {dim_count} dimensional members", context.id),
+            ));
         }
     }
 
@@ -267,29 +261,26 @@ pub fn validate_context_completeness_streaming(
             // Check for facts referencing non-existent contexts
             for fact in &handler.facts {
                 if !handler.contexts.contains(&fact.context_ref) {
-                    findings.push(ValidationFinding {
-                        rule_id: "XBRL.CONTEXT.MISSING_REF".to_string(),
-                        severity: "error".to_string(),
-                        message: format!(
+                    findings.push(ValidationFinding::for_context(
+                        "XBRL.CONTEXT.MISSING_REF",
+                        "error",
+                        &fact.context_ref,
+                        format!(
                             "Fact '{}' references undefined context '{}'",
                             fact.concept, fact.context_ref
                         ),
-                        member: None,
-                        subject: Some(fact.context_ref.clone()),
-                    });
+                    ));
                 }
             }
 
             findings
         }
         Err(e) => {
-            vec![ValidationFinding {
-                rule_id: "XBRL.STREAM_PARSE_ERROR".to_string(),
-                severity: "error".to_string(),
-                message: format!("Streaming parse failed: {e}"),
-                member: None,
-                subject: None,
-            }]
+            vec![ValidationFinding::new(
+                "XBRL.STREAM_PARSE_ERROR",
+                "error",
+                format!("Streaming parse failed: {e}"),
+            )]
         }
     }
 }

--- a/crates/xbrl-report-types/src/lib.rs
+++ b/crates/xbrl-report-types/src/lib.rs
@@ -23,6 +23,195 @@ pub struct ValidationFinding {
     pub subject: Option<String>,
 }
 
+impl ValidationFinding {
+    /// Create a baseline finding with no member or subject.
+    pub fn new(
+        rule_id: impl Into<String>,
+        severity: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule_id: rule_id.into(),
+            severity: severity.into(),
+            message: message.into(),
+            member: None,
+            subject: None,
+        }
+    }
+
+    /// Create a finding from a fact, using `fact.member` and `fact.concept`.
+    pub fn for_fact(
+        rule_id: impl Into<String>,
+        severity: impl Into<String>,
+        fact: &Fact,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule_id: rule_id.into(),
+            severity: severity.into(),
+            message: message.into(),
+            member: Some(fact.member.clone()),
+            subject: Some(fact.concept.clone()),
+        }
+    }
+
+    /// Create a finding tied to a context, using `context_id` as the subject.
+    pub fn for_context(
+        rule_id: impl Into<String>,
+        severity: impl Into<String>,
+        context_id: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule_id: rule_id.into(),
+            severity: severity.into(),
+            message: message.into(),
+            member: None,
+            subject: Some(context_id.into()),
+        }
+    }
+
+    /// Create a finding from a dimension-member pair.
+    ///
+    /// `dimension` maps to the `member` field; `member` maps to the `subject` field,
+    /// matching the domain convention used in dimensional validation.
+    pub fn for_dimension_member(
+        rule_id: impl Into<String>,
+        severity: impl Into<String>,
+        dimension: impl Into<String>,
+        member: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule_id: rule_id.into(),
+            severity: severity.into(),
+            message: message.into(),
+            member: Some(dimension.into()),
+            subject: Some(member.into()),
+        }
+    }
+
+    /// Set the member field (builder-style).
+    #[must_use]
+    pub fn with_member(mut self, member: impl Into<String>) -> Self {
+        self.member = Some(member.into());
+        self
+    }
+
+    /// Set the subject field (builder-style).
+    #[must_use]
+    pub fn with_subject(mut self, subject: impl Into<String>) -> Self {
+        self.subject = Some(subject.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_sets_rule_id_severity_message_and_none_fields() {
+        let finding = ValidationFinding::new("RULE-1", "error", "Something went wrong");
+
+        assert_eq!(finding.rule_id, "RULE-1");
+        assert_eq!(finding.severity, "error");
+        assert_eq!(finding.message, "Something went wrong");
+        assert_eq!(finding.member, None);
+        assert_eq!(finding.subject, None);
+    }
+
+    #[test]
+    fn for_fact_populates_member_and_subject_from_fact() {
+        let fact = Fact {
+            concept: "us-gaap:Revenue".to_string(),
+            context_ref: "ctx-1".to_string(),
+            unit_ref: None,
+            decimals: None,
+            value: "1000".to_string(),
+            member: "member-a".to_string(),
+        };
+
+        let finding =
+            ValidationFinding::for_fact("SEC.RULE", "error", &fact, "Negative value");
+
+        assert_eq!(finding.rule_id, "SEC.RULE");
+        assert_eq!(finding.severity, "error");
+        assert_eq!(finding.message, "Negative value");
+        assert_eq!(finding.member, Some("member-a".to_string()));
+        assert_eq!(finding.subject, Some("us-gaap:Revenue".to_string()));
+    }
+
+    #[test]
+    fn for_context_sets_subject_to_context_id_and_none_member() {
+        let finding =
+            ValidationFinding::for_context("CTX.RULE", "warning", "ctx-1", "Missing entity");
+
+        assert_eq!(finding.rule_id, "CTX.RULE");
+        assert_eq!(finding.severity, "warning");
+        assert_eq!(finding.message, "Missing entity");
+        assert_eq!(finding.member, None);
+        assert_eq!(finding.subject, Some("ctx-1".to_string()));
+    }
+
+    #[test]
+    fn for_dimension_member_maps_dimension_to_member_and_member_to_subject() {
+        let finding = ValidationFinding::for_dimension_member(
+            "DIM.RULE",
+            "error",
+            "us-gaap:ScenarioAxis",
+            "us-gaap:ActualMember",
+            "Invalid member",
+        );
+
+        assert_eq!(finding.rule_id, "DIM.RULE");
+        assert_eq!(finding.severity, "error");
+        assert_eq!(finding.message, "Invalid member");
+        assert_eq!(finding.member, Some("us-gaap:ScenarioAxis".to_string()));
+        assert_eq!(finding.subject, Some("us-gaap:ActualMember".to_string()));
+    }
+
+    #[test]
+    fn with_member_adds_member_to_new_finding() {
+        let finding = ValidationFinding::new("RULE", "error", "msg").with_member("member-a");
+        assert_eq!(finding.member, Some("member-a".to_string()));
+        assert_eq!(finding.subject, None);
+    }
+
+    #[test]
+    fn with_subject_adds_subject_to_new_finding() {
+        let finding = ValidationFinding::new("RULE", "error", "msg").with_subject("ctx-1");
+        assert_eq!(finding.member, None);
+        assert_eq!(finding.subject, Some("ctx-1".to_string()));
+    }
+
+    #[test]
+    fn with_member_and_subject_chain_on_new() {
+        let finding = ValidationFinding::new("RULE", "error", "msg")
+            .with_member("dim")
+            .with_subject("subj");
+        assert_eq!(finding.member, Some("dim".to_string()));
+        assert_eq!(finding.subject, Some("subj".to_string()));
+    }
+
+    #[test]
+    fn for_fact_with_empty_member_gives_some_empty_string() {
+        let fact = Fact {
+            concept: "us-gaap:Revenue".to_string(),
+            context_ref: "ctx-1".to_string(),
+            unit_ref: None,
+            decimals: None,
+            value: "1000".to_string(),
+            member: String::new(),
+        };
+
+        let finding = ValidationFinding::for_fact("RULE", "error", &fact, "msg");
+
+        // Empty member is still Some("") because it came from the fact field
+        assert_eq!(finding.member, Some("".to_string()));
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct CanonicalReport {
     #[serde(default)]


### PR DESCRIPTION
## Summary

Phase 1 implementation for #336 — reduces clone-heavy `ValidationFinding` construction across the workspace.

### Changes
- **Constructors added** to `ValidationFinding`:
  - `new(rule_id, severity, message)` — baseline
  - `for_fact(rule_id, severity, fact, message)` — from Fact
  - `for_context(rule_id, severity, context_id, message)` — from context ID
  - `for_dimension_member(rule_id, severity, dimension, member, message)` — from dimension/member pair
- **Builder methods**: `with_member()`, `with_subject()` for custom patterns
- **Unit tests** for all constructors and builder methods

### Call sites migrated
| Crate | Before (clones) | After |
|-------|----------------|-------|
| `numeric-rules` | 4 | `for_fact` |
| `decimal_precision` | 2 | `for_fact` |
| `unit-rules` | 2 | `for_fact` |
| `context-completeness` | 2 | `for_fact` |
| `dimensional-rules` | 26 | `for_dimension_member` / `new` + builders |
| `validation-run` | 10 | `new` / `for_context` |

### Validation
- `cargo build --workspace` ✅
- `cargo test --workspace` ✅ (all tests pass)
- `cargo clippy --workspace` ✅ (clean)
- `cargo xtask alpha-check` ✅ (alpha gate passed)

### Deferred
- Phase 2 (`Arc\u003cstr\u003e` for `member` / `subject`) — follow-up PR

Closes #336 (Phase 1)